### PR TITLE
Configure and securely validate Torrentio

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,0 +1,2 @@
+# Generate a local value with: openssl rand -base64 32
+CONFIG_SECRET=replace-with-at-least-32-random-characters

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ node_modules/
 .wrangler/
 npm-debug.log*
 .env
+.dev.vars
 .DS_Store
 .pi/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kids Channels
 
-A Cloudflare Worker Stremio addon that gives each Household one clearly identifiable TV Channel and one Movie Channel. This first vertical slice creates PIN-protected Households and installs an empty, Household-specific addon backed by D1.
+A Cloudflare Worker Stremio addon that gives each Household one clearly identifiable TV Channel and one Movie Channel. Parents create PIN-protected Households and can securely configure and validate an existing Torrentio/Real-Debrid endpoint.
 
 ## Requirements
 
@@ -12,11 +12,13 @@ A Cloudflare Worker Stremio addon that gives each Household one clearly identifi
 
 ```bash
 pnpm install
+cp .dev.vars.example .dev.vars
+# Replace CONFIG_SECRET in .dev.vars with: openssl rand -base64 32
 pnpm db:migrate:local
 pnpm dev
 ```
 
-Open `http://localhost:8787`, choose a six-digit Parent PIN, and create a Household. The page returns the opaque manifest URL and a `stremio://` installation action.
+Keep `.dev.vars` private; changing `CONFIG_SECRET` makes existing encrypted provider configurations unreadable. Open `http://localhost:8787`, choose a six-digit Parent PIN, and create a Household. The page returns the opaque manifest URL and a `stremio://` installation action.
 
 Local D1 data is stored by Wrangler under `.wrangler/`. There is no forgotten-PIN recovery.
 
@@ -27,7 +29,9 @@ pnpm typecheck
 pnpm test
 ```
 
-The integration and protocol suite runs the complete creation, PIN unlock, manifest, and catalog flow inside the Cloudflare Worker runtime against an isolated test D1 database.
+The integration and protocol suite runs the complete creation, PIN unlock, provider validation, encrypted storage, manifest, and catalog flow inside the Cloudflare Worker runtime against an isolated test D1 database. Torrentio is stubbed only at outbound `fetch`; deterministic tests contain no real credentials or signed media URLs.
+
+A credential-safe real-provider check is documented separately in [`docs/torrentio-contract-probe.md`](docs/torrentio-contract-probe.md). It is optional and never runs in CI.
 
 ## Deploy
 
@@ -37,20 +41,23 @@ Create the production D1 database once:
 pnpm exec wrangler d1 create kids-channels
 ```
 
-Copy the returned `database_id` into `wrangler.jsonc`, replacing the all-zero placeholder. Then migrate and deploy:
+Copy the returned `database_id` into `wrangler.jsonc`, replacing the all-zero placeholder. Create a random deployment secret, then migrate and deploy:
 
 ```bash
+openssl rand -base64 32 | pnpm exec wrangler secret put CONFIG_SECRET
 pnpm db:migrate:remote
 pnpm deploy
 ```
 
-The Worker never places the Parent PIN or provider credentials in installation URLs. Household routes use a random 256-bit opaque secret; PINs are salted and hashed with PBKDF2-SHA-256 before storage.
+The Worker never places the Parent PIN or provider credentials in installation URLs. Household routes use a random 256-bit opaque secret; PINs are salted and hashed with PBKDF2-SHA-256. Torrentio manifest URLs are AES-GCM encrypted with Household-bound authenticated data and the deployment secret, and are never returned after saving.
 
 ## Routes
 
 - `GET /` — minimal Household creation Parent Page
 - `POST /api/households` — create a Household with a six-digit PIN
 - `GET /households/:secret` — PIN unlock Parent Page
+- `POST /api/households/:secret/unlock` — authenticate a Parent for one hour
+- `PUT /api/households/:secret/provider` — save and validate a Torrentio endpoint (Parent bearer token required)
 - `GET /addons/:secret/manifest.json` — Household Stremio manifest
 - `GET /addons/:secret/catalog/tv/kids-tv-channel.json` — one TV Channel tile
 - `GET /addons/:secret/catalog/movie/kids-movie-channel.json` — one Movie Channel tile

--- a/docs/torrentio-contract-probe.md
+++ b/docs/torrentio-contract-probe.md
@@ -1,0 +1,14 @@
+# Optional Torrentio contract probe
+
+This manual probe checks the current hosted Torrentio contract with a developer-supplied configured endpoint. It is deliberately separate from deterministic tests and must not run in CI.
+
+The manifest URL is a credential: do not paste it into an issue, commit it, put it on a command line, enable shell tracing, or retain terminal output from other tools. The probe prints only result counts and generic failures; it never prints request URLs, provider bodies, or stream URLs.
+
+```bash
+read -rsp 'Torrentio manifest URL: ' TORRENTIO_MANIFEST_URL && echo
+export TORRENTIO_MANIFEST_URL
+pnpm probe:torrentio
+unset TORRENTIO_MANIFEST_URL
+```
+
+The probe checks the manifest and requests streams for the representative movie `tt0111161`. Success confirms only that the hosted interface is reachable and reports how many cached direct and acceptable 1080p results were observed at that moment. It does not replace a Fire TV playback check.

--- a/migrations/0002_add_torrentio_configuration.sql
+++ b/migrations/0002_add_torrentio_configuration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE households ADD COLUMN torrentio_ciphertext TEXT;
+ALTER TABLE households ADD COLUMN torrentio_nonce TEXT;
+ALTER TABLE households ADD COLUMN torrentio_validation_status TEXT;
+ALTER TABLE households ADD COLUMN torrentio_configured_at TEXT;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "deploy": "wrangler deploy",
     "db:migrate:local": "wrangler d1 migrations apply kids-channels --local",
     "db:migrate:remote": "wrangler d1 migrations apply kids-channels --remote",
+    "probe:torrentio": "node scripts/probe-torrentio.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc"

--- a/scripts/probe-torrentio.mjs
+++ b/scripts/probe-torrentio.mjs
@@ -1,0 +1,30 @@
+const manifestValue = process.env.TORRENTIO_MANIFEST_URL;
+if (!manifestValue) {
+  console.error("Set TORRENTIO_MANIFEST_URL to a configured HTTPS manifest URL.");
+  process.exitCode = 2;
+} else {
+  try {
+    const manifestUrl = new URL(manifestValue);
+    if (manifestUrl.protocol !== "https:" || !manifestUrl.pathname.endsWith("/manifest.json")) throw new Error();
+
+    const manifestResponse = await fetch(manifestUrl, { headers: { accept: "application/json" } });
+    const manifest = await manifestResponse.json();
+    if (!manifestResponse.ok || typeof manifest.id !== "string" || !Array.isArray(manifest.resources)) throw new Error();
+
+    const streamUrl = new URL(manifestUrl);
+    streamUrl.pathname = `${streamUrl.pathname.slice(0, -"manifest.json".length)}stream/movie/tt0111161.json`;
+    const streamResponse = await fetch(streamUrl, { headers: { accept: "application/json" } });
+    const body = await streamResponse.json();
+    if (!streamResponse.ok || !Array.isArray(body.streams)) throw new Error();
+
+    const cached = body.streams.filter((stream) => {
+      const label = `${stream?.name ?? ""}\n${stream?.title ?? ""}`;
+      return typeof stream?.url === "string" && /(?:^|\s|\n)RD\+(?:\s|$)/i.test(label) && !/download/i.test(label);
+    });
+    const acceptable = cached.filter((stream) => /\b1080p?\b/i.test(`${stream?.name ?? ""}\n${stream?.title ?? ""}`));
+    console.log(`Probe succeeded: manifest valid; cached direct results=${cached.length}; acceptable 1080p results=${acceptable.length}.`);
+  } catch {
+    console.error("Probe failed: the manifest or representative stream request was not usable.");
+    process.exitCode = 1;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,12 @@
 import { createHousehold, findHousehold, validPin, verifyPin } from "./households";
+import { providerConfiguration, saveProviderConfiguration } from "./provider-config";
+import { issueParentToken, verifyParentToken } from "./secrets";
+import { parseTorrentioManifestUrl, TorrentioProvider } from "./stream-provider";
 import { catalogFor, manifestFor } from "./stremio";
 
 export interface Env {
   DB: D1Database;
+  CONFIG_SECRET?: string;
 }
 
 const jsonHeaders = {
@@ -39,7 +43,8 @@ function shell(content: string, title = "Kids Channels"): string {
     h1 { margin-top: 0; } p { line-height: 1.55; color: #cbd0ea; }
     label { display: block; font-weight: 700; margin: 1.5rem 0 .5rem; }
     input, button, .button { box-sizing: border-box; width: 100%; min-height: 3rem; border-radius: .6rem; border: 1px solid #566098; padding: .7rem 1rem; font: inherit; }
-    input { background: #0e1224; color: white; font-size: 1.25rem; letter-spacing: .2em; }
+    input { background: #0e1224; color: white; font-size: 1.25rem; }
+    input[name="pin"] { letter-spacing: .2em; }
     button, .button { display: block; cursor: pointer; background: #725cff; border-color: #8c7aff; color: white; font-weight: 800; text-align: center; text-decoration: none; margin-top: 1rem; }
     .secondary { background: transparent; }
     .notice { border-left: .25rem solid #ffca5c; padding-left: 1rem; }
@@ -114,9 +119,17 @@ function parentPage(secret: string): string {
       <h2>Household unlocked</h2>
       <a id="install" class="button" href="#">Install in Stremio</a>
       <p>Manifest: <code id="manifest"></code></p>
+      <form id="provider-form">
+        <label for="manifest-url">Torrentio manifest URL</label>
+        <input id="manifest-url" name="manifestUrl" type="url" placeholder="https://…/manifest.json" autocomplete="off" required>
+        <p class="notice">This URL contains credentials. It is encrypted when saved and will not be shown again.</p>
+        <button type="submit">Save and validate Torrentio</button>
+        <p id="provider-result" role="status"></p>
+      </form>
     </section>
     <script>
       const form = document.querySelector('#unlock-form');
+      let parentToken = '';
       form.addEventListener('submit', async (event) => {
         event.preventDefault();
         const response = await fetch('/api/households/${secret}/unlock', {
@@ -125,10 +138,26 @@ function parentPage(secret: string): string {
         });
         const result = await response.json();
         if (!response.ok) { document.querySelector('#error').textContent = result.error; return; }
+        parentToken = result.parentToken;
         document.querySelector('#install').href = result.installUrl;
         document.querySelector('#manifest').textContent = result.manifestUrl;
+        document.querySelector('#provider-result').textContent = result.provider.configured
+          ? result.provider.validation.message + ' Enter a new URL to replace it.' : 'Torrentio is not configured.';
         form.hidden = true;
         document.querySelector('#result').hidden = false;
+      });
+      document.querySelector('#provider-form').addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const output = document.querySelector('#provider-result');
+        output.textContent = 'Checking Torrentio manifest and a representative stream…';
+        const response = await fetch('/api/households/${secret}/provider', {
+          method: 'PUT',
+          headers: {'content-type': 'application/json', authorization: 'Bearer ' + parentToken},
+          body: JSON.stringify({manifestUrl: new FormData(event.currentTarget).get('manifestUrl')})
+        });
+        const result = await response.json();
+        output.textContent = response.ok ? result.validation.message : result.error;
+        if (response.ok) event.currentTarget.reset();
       });
     </script>`);
 }
@@ -150,13 +179,19 @@ async function parsePin(request: Request): Promise<unknown> {
   }
 }
 
+async function authorizedParent(request: Request, householdId: string, deploymentSecret: string): Promise<boolean> {
+  const authorization = request.headers.get("authorization");
+  if (!authorization?.startsWith("Bearer ")) return false;
+  return verifyParentToken(authorization.slice(7), householdId, deploymentSecret);
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
     const path = url.pathname;
 
     if (request.method === "OPTIONS") {
-      return new Response(null, { status: 204, headers: { ...jsonHeaders, "access-control-allow-methods": "GET, POST, OPTIONS", "access-control-allow-headers": "content-type" } });
+      return new Response(null, { status: 204, headers: { ...jsonHeaders, "access-control-allow-methods": "GET, POST, PUT, OPTIONS", "access-control-allow-headers": "content-type, authorization" } });
     }
 
     if (request.method === "GET" && path === "/") return html(homePage());
@@ -175,7 +210,33 @@ export default {
       const pin = await parsePin(request);
       if (!validPin(pin)) return json({ error: "PIN must contain exactly six digits." }, 400);
       if (!(await verifyPin(env.DB, unlockMatch[1], pin))) return json({ error: "Household or PIN is incorrect." }, 401);
-      return json(installDetails(url.origin, unlockMatch[1]));
+      const household = await findHousehold(env.DB, unlockMatch[1]);
+      if (!household) return json({ error: "Household or PIN is incorrect." }, 401);
+      if (!env.CONFIG_SECRET) return json({ error: "Provider configuration is unavailable." }, 503);
+      return json({
+        ...installDetails(url.origin, unlockMatch[1]),
+        parentToken: await issueParentToken(household.id, env.CONFIG_SECRET),
+        provider: await providerConfiguration(env.DB, household.id),
+      });
+    }
+
+    const providerMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/provider$/);
+    if (request.method === "PUT" && providerMatch) {
+      const household = await findHousehold(env.DB, providerMatch[1]);
+      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household.id, env.CONFIG_SECRET))) {
+        return json({ error: "Parent authentication is required." }, 401);
+      }
+      let manifestValue: unknown;
+      try {
+        manifestValue = ((await request.json()) as { manifestUrl?: unknown }).manifestUrl;
+      } catch {
+        // Invalid JSON is handled as an invalid endpoint without reflecting request content.
+      }
+      const manifestUrl = parseTorrentioManifestUrl(manifestValue);
+      if (!manifestUrl) return json({ error: "Enter a valid HTTPS Torrentio manifest URL ending in /manifest.json." }, 400);
+      const validation = await new TorrentioProvider(manifestUrl).validate();
+      const saved = await saveProviderConfiguration(env.DB, household.id, manifestUrl.toString(), env.CONFIG_SECRET, validation);
+      return json(saved);
     }
 
     const parentMatch = path.match(/^\/households\/([A-Za-z0-9_-]+)$/);

--- a/src/provider-config.ts
+++ b/src/provider-config.ts
@@ -1,0 +1,59 @@
+import { decryptCredential, encryptCredential } from "./secrets";
+import type { ValidationResult, ValidationStatus } from "./stream-provider";
+
+export interface ProviderConfiguration {
+  configured: boolean;
+  validation?: ValidationResult;
+  updatedAt?: string;
+}
+
+interface StoredConfiguration {
+  torrentio_ciphertext: string | null;
+  torrentio_nonce: string | null;
+  torrentio_validation_status: ValidationStatus | null;
+  torrentio_configured_at: string | null;
+}
+
+const messages: Record<ValidationStatus, string> = {
+  acceptable_cached: "Torrentio returned an acceptable cached 1080p direct stream.",
+  no_cached_result: "Torrentio returned no cached direct stream for the validation title.",
+  unsuitable_results: "Torrentio returned cached streams, but none were suitable 1080p results.",
+  provider_failure: "Torrentio could not be validated. Check the endpoint and try again.",
+};
+
+export async function saveProviderConfiguration(
+  db: D1Database,
+  householdId: string,
+  manifestUrl: string,
+  deploymentSecret: string,
+  validation: ValidationResult,
+): Promise<ProviderConfiguration> {
+  const encrypted = await encryptCredential(manifestUrl, deploymentSecret, householdId);
+  const updatedAt = new Date().toISOString();
+  await db.prepare(`UPDATE households
+    SET torrentio_ciphertext = ?, torrentio_nonce = ?, torrentio_validation_status = ?, torrentio_configured_at = ?
+    WHERE id = ?`)
+    .bind(encrypted.ciphertext, encrypted.nonce, validation.status, updatedAt, householdId)
+    .run();
+  return { configured: true, validation, updatedAt };
+}
+
+export async function providerConfiguration(db: D1Database, householdId: string): Promise<ProviderConfiguration> {
+  const stored = await db.prepare(`SELECT torrentio_ciphertext, torrentio_nonce,
+    torrentio_validation_status, torrentio_configured_at FROM households WHERE id = ?`)
+    .bind(householdId).first<StoredConfiguration>();
+  if (!stored?.torrentio_ciphertext) return { configured: false };
+  const status = stored.torrentio_validation_status ?? "provider_failure";
+  return {
+    configured: true,
+    validation: { status, message: messages[status] },
+    updatedAt: stored.torrentio_configured_at ?? undefined,
+  };
+}
+
+export async function decryptedManifestUrl(db: D1Database, householdId: string, deploymentSecret: string): Promise<string | null> {
+  const stored = await db.prepare("SELECT torrentio_ciphertext, torrentio_nonce FROM households WHERE id = ?")
+    .bind(householdId).first<StoredConfiguration>();
+  if (!stored?.torrentio_ciphertext || !stored.torrentio_nonce) return null;
+  return decryptCredential(stored.torrentio_ciphertext, stored.torrentio_nonce, deploymentSecret, householdId);
+}

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -1,0 +1,64 @@
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function toBase64Url(bytes: ArrayBuffer | Uint8Array): string {
+  const view = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  let binary = "";
+  for (const byte of view) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
+
+function fromBase64Url(value: string): Uint8Array<ArrayBuffer> {
+  const padded = value.replaceAll("-", "+").replaceAll("_", "/").padEnd(Math.ceil(value.length / 4) * 4, "=");
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
+  return bytes;
+}
+
+async function keyMaterial(secret: string): Promise<ArrayBuffer> {
+  if (secret.length < 32) throw new Error("CONFIG_SECRET must contain at least 32 characters");
+  return crypto.subtle.digest("SHA-256", encoder.encode(secret));
+}
+
+export async function encryptCredential(value: string, secret: string, householdId: string): Promise<{ ciphertext: string; nonce: string }> {
+  const key = await crypto.subtle.importKey("raw", await keyMaterial(secret), "AES-GCM", false, ["encrypt"]);
+  const nonce = crypto.getRandomValues(new Uint8Array(12));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: nonce, additionalData: encoder.encode(householdId) },
+    key,
+    encoder.encode(value),
+  );
+  return { ciphertext: toBase64Url(ciphertext), nonce: toBase64Url(nonce) };
+}
+
+export async function decryptCredential(ciphertext: string, nonce: string, secret: string, householdId: string): Promise<string> {
+  const key = await crypto.subtle.importKey("raw", await keyMaterial(secret), "AES-GCM", false, ["decrypt"]);
+  const plaintext = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: fromBase64Url(nonce), additionalData: encoder.encode(householdId) },
+    key,
+    fromBase64Url(ciphertext),
+  );
+  return decoder.decode(plaintext);
+}
+
+export async function issueParentToken(householdId: string, secret: string, now = Date.now()): Promise<string> {
+  const payload = toBase64Url(encoder.encode(JSON.stringify({ expiresAt: now + 60 * 60 * 1000 })));
+  const key = await crypto.subtle.importKey("raw", await keyMaterial(secret), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(`${householdId}.${payload}`));
+  return `${payload}.${toBase64Url(signature)}`;
+}
+
+export async function verifyParentToken(token: string, householdId: string, secret: string, now = Date.now()): Promise<boolean> {
+  try {
+    const [payload, signature, extra] = token.split(".");
+    if (!payload || !signature || extra) return false;
+    const key = await crypto.subtle.importKey("raw", await keyMaterial(secret), { name: "HMAC", hash: "SHA-256" }, false, ["verify"]);
+    const valid = await crypto.subtle.verify("HMAC", key, fromBase64Url(signature), encoder.encode(`${householdId}.${payload}`));
+    if (!valid) return false;
+    const parsed = JSON.parse(decoder.decode(fromBase64Url(payload))) as { expiresAt?: unknown };
+    return typeof parsed.expiresAt === "number" && parsed.expiresAt > now;
+  } catch {
+    return false;
+  }
+}

--- a/src/stream-provider.ts
+++ b/src/stream-provider.ts
@@ -1,0 +1,104 @@
+export interface ProviderStream {
+  name?: string;
+  title?: string;
+  url?: string;
+  [key: string]: unknown;
+}
+
+export type ValidationStatus = "acceptable_cached" | "no_cached_result" | "unsuitable_results" | "provider_failure";
+
+export interface ValidationResult {
+  status: ValidationStatus;
+  message: string;
+}
+
+export interface StreamProvider {
+  validate(): Promise<ValidationResult>;
+  streams(type: "movie" | "series", id: string): Promise<ProviderStream[]>;
+  firstAcceptable(streams: ProviderStream[]): ProviderStream | null;
+}
+
+const validationMessages: Record<ValidationStatus, string> = {
+  acceptable_cached: "Torrentio returned an acceptable cached 1080p direct stream.",
+  no_cached_result: "Torrentio returned no cached direct stream for the validation title.",
+  unsuitable_results: "Torrentio returned cached streams, but none were suitable 1080p results.",
+  provider_failure: "Torrentio could not be validated. Check the endpoint and try again.",
+};
+
+function direct(stream: ProviderStream): boolean {
+  if (typeof stream.url !== "string") return false;
+  try {
+    const protocol = new URL(stream.url).protocol;
+    return protocol === "https:" || protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+function cached(stream: ProviderStream): boolean {
+  const label = `${stream.name ?? ""}\n${stream.title ?? ""}`;
+  return direct(stream) && /(?:^|\s|\n)RD\+(?:\s|$)/i.test(label) && !/download/i.test(label);
+}
+
+function suitable(stream: ProviderStream): boolean {
+  return cached(stream) && /\b1080p?\b/i.test(`${stream.name ?? ""}\n${stream.title ?? ""}`);
+}
+
+export function firstAcceptableCachedStream(streams: ProviderStream[]): ProviderStream | null {
+  return streams.find(suitable) ?? null;
+}
+
+export function parseTorrentioManifestUrl(value: unknown): URL | null {
+  if (typeof value !== "string" || value.length > 4096) return null;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:" || url.username || url.password || url.hash || !url.pathname.endsWith("/manifest.json")) return null;
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+export class TorrentioProvider implements StreamProvider {
+  constructor(private readonly manifestUrl: URL, private readonly request: typeof fetch = fetch) {}
+
+  private streamUrl(type: "movie" | "series", id: string): URL {
+    const url = new URL(this.manifestUrl);
+    url.pathname = `${url.pathname.slice(0, -"manifest.json".length)}stream/${type}/${encodeURIComponent(id)}.json`;
+    return url;
+  }
+
+  async streams(type: "movie" | "series", id: string): Promise<ProviderStream[]> {
+    const response = await this.request(this.streamUrl(type, id), {
+      headers: { accept: "application/json" },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) throw new Error("provider request failed");
+    const body = await response.json() as { streams?: unknown };
+    if (!Array.isArray(body.streams)) throw new Error("provider response invalid");
+    return body.streams.filter((stream): stream is ProviderStream => typeof stream === "object" && stream !== null);
+  }
+
+  firstAcceptable(streams: ProviderStream[]): ProviderStream | null {
+    return firstAcceptableCachedStream(streams);
+  }
+
+  async validate(): Promise<ValidationResult> {
+    try {
+      const manifestResponse = await this.request(this.manifestUrl, {
+        headers: { accept: "application/json" },
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!manifestResponse.ok) throw new Error("manifest request failed");
+      const manifest = await manifestResponse.json() as { id?: unknown; resources?: unknown };
+      if (typeof manifest.id !== "string" || !Array.isArray(manifest.resources)) throw new Error("manifest response invalid");
+
+      const streams = await this.streams("movie", "tt0111161");
+      if (this.firstAcceptable(streams)) return { status: "acceptable_cached", message: validationMessages.acceptable_cached };
+      if (streams.some(cached)) return { status: "unsuitable_results", message: validationMessages.unsuitable_results };
+      return { status: "no_cached_result", message: validationMessages.no_cached_result };
+    } catch {
+      return { status: "provider_failure", message: validationMessages.provider_failure };
+    }
+  }
+}

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -1,5 +1,7 @@
 import { env, SELF } from "cloudflare:test";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { decryptedManifestUrl } from "../src/provider-config";
+import { firstAcceptableCachedStream } from "../src/stream-provider";
 
 interface CreatedHousehold {
   householdId: string;
@@ -14,10 +16,15 @@ beforeEach(async () => {
     secret TEXT UNIQUE NOT NULL,
     pin_salt TEXT NOT NULL,
     pin_hash TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    torrentio_ciphertext TEXT,
+    torrentio_nonce TEXT,
+    torrentio_validation_status TEXT,
+    torrentio_configured_at TEXT
   )`).run();
   await env.DB.prepare("CREATE INDEX IF NOT EXISTS households_secret_idx ON households (secret)").run();
   await env.DB.prepare("DELETE FROM households").run();
+  vi.restoreAllMocks();
 });
 
 async function create(pin = "123456"): Promise<CreatedHousehold> {
@@ -76,7 +83,9 @@ describe("Parent Page Household creation", () => {
 
     const parentPage = await SELF.fetch(created.parentUrl);
     expect(parentPage.status).toBe(200);
-    expect(await parentPage.text()).toContain("Enter your six-digit PIN");
+    const parentHtml = await parentPage.text();
+    expect(parentHtml).toContain("Enter your six-digit PIN");
+    expect(parentHtml).toContain("Torrentio manifest URL");
 
     const denied = await SELF.fetch(`https://kids.test/api/households/${secret}/unlock`, {
       method: "POST",
@@ -92,6 +101,119 @@ describe("Parent Page Household creation", () => {
     });
     expect(unlocked.status).toBe(200);
     expect(await unlocked.json()).toMatchObject({ manifestUrl: created.manifestUrl });
+  });
+});
+
+describe("Torrentio configuration", () => {
+  const providerOrigin = "https://torrentio.example";
+  const providerPath = "/providers=test/realdebrid=REDACTED";
+  const manifestUrl = `${providerOrigin}${providerPath}/manifest.json`;
+  const deploymentSecret = "test-only-configuration-secret-at-least-32-characters";
+
+  function mockTorrentio(streams: unknown[], manifestStatus = 200, streamStatus = 200) {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const path = new URL(input instanceof Request ? input.url : input.toString()).pathname;
+      if (path === `${providerPath}/manifest.json`) {
+        return Response.json(manifestStatus === 200 ? { id: "org.example.torrentio", resources: ["stream"] } : {}, { status: manifestStatus });
+      }
+      if (path === `${providerPath}/stream/movie/tt0111161.json`) {
+        return Response.json(streamStatus === 200 ? { streams } : {}, { status: streamStatus });
+      }
+      throw new Error("unexpected outbound request");
+    });
+  }
+
+  async function unlock(created: CreatedHousehold): Promise<string> {
+    const response = await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/unlock`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ pin: "123456" }),
+    });
+    return (await response.json<{ parentToken: string }>()).parentToken;
+  }
+
+  async function save(created: CreatedHousehold, parentToken: string) {
+    return SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/provider`, {
+      method: "PUT",
+      headers: { "content-type": "application/json", authorization: `Bearer ${parentToken}` },
+      body: JSON.stringify({ manifestUrl }),
+    });
+  }
+
+  it("requires an authenticated Parent and never returns the configured credential", async () => {
+    const created = await create();
+    const denied = await save(created, "invalid-token");
+    expect(denied.status).toBe(401);
+
+    mockTorrentio([{ name: "Torrentio\nRD+", title: "Example 1080p", url: "https://media.example/video" }]);
+    const accepted = await save(created, await unlock(created));
+    const body = await accepted.text();
+    expect(accepted.status).toBe(200);
+    expect(body).not.toContain(manifestUrl);
+    expect(body).not.toContain("REDACTED");
+    expect(JSON.parse(body)).toMatchObject({ configured: true, validation: { status: "acceptable_cached" } });
+
+    const stored = await env.DB.prepare("SELECT torrentio_ciphertext, torrentio_nonce FROM households WHERE id = ?")
+      .bind(created.householdId).first<{ torrentio_ciphertext: string; torrentio_nonce: string }>();
+    expect(stored?.torrentio_ciphertext).not.toContain("REDACTED");
+    expect(stored?.torrentio_nonce).toBeTruthy();
+    expect(await decryptedManifestUrl(env.DB, created.householdId, deploymentSecret)).toBe(manifestUrl);
+
+    const tampered = `${stored?.torrentio_ciphertext[0] === "A" ? "B" : "A"}${stored?.torrentio_ciphertext.slice(1)}`;
+    await env.DB.prepare("UPDATE households SET torrentio_ciphertext = ? WHERE id = ?")
+      .bind(tampered, created.householdId).run();
+    await expect(decryptedManifestUrl(env.DB, created.householdId, deploymentSecret)).rejects.toThrow();
+  });
+
+  it.each([
+    [[], "no_cached_result"],
+    [[{ name: "Torrentio\nRD download", title: "Example 1080p", url: "https://media.example/download" }], "no_cached_result"],
+    [[{ name: "Torrentio\nRD+", title: "Example 2160p", url: "https://media.example/video" }], "unsuitable_results"],
+  ])("distinguishes validation result %#", async (streams, expected) => {
+    const created = await create();
+    mockTorrentio(streams);
+    const response = await save(created, await unlock(created));
+    expect(await response.json<any>()).toMatchObject({ validation: { status: expected } });
+  });
+
+  it("reports provider failure without exposing provider response details", async () => {
+    const created = await create();
+    mockTorrentio([], 503);
+    const response = await save(created, await unlock(created));
+    const body = await response.text();
+    expect(JSON.parse(body)).toMatchObject({ validation: { status: "provider_failure" } });
+    expect(body).not.toContain(manifestUrl);
+    expect(body).not.toContain("REDACTED");
+  });
+
+  it("replaces an existing encrypted configuration", async () => {
+    const created = await create();
+    const token = await unlock(created);
+    mockTorrentio([{ name: "Torrentio\nRD+", title: "Example 1080p", url: "https://media.example/video" }]);
+    await save(created, token);
+    const first = await env.DB.prepare("SELECT torrentio_ciphertext FROM households WHERE id = ?")
+      .bind(created.householdId).first<{ torrentio_ciphertext: string }>();
+
+    mockTorrentio([{ name: "Torrentio\nRD+", title: "Example 1080p", url: "https://media.example/video" }]);
+    await save(created, token);
+    const second = await env.DB.prepare("SELECT torrentio_ciphertext FROM households WHERE id = ?")
+      .bind(created.householdId).first<{ torrentio_ciphertext: string }>();
+    expect(second?.torrentio_ciphertext).not.toBe(first?.torrentio_ciphertext);
+
+    const unlocked = await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/unlock`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ pin: "123456" }),
+    });
+    const body = await unlocked.text();
+    expect(JSON.parse(body)).toMatchObject({ provider: { configured: true, validation: { status: "acceptable_cached" } } });
+    expect(body).not.toContain("REDACTED");
+  });
+
+  it("preserves provider ordering when selecting the first acceptable cached direct stream", () => {
+    const first = { name: "Torrentio\nRD+", title: "First 1080p", url: "https://media.example/first" };
+    const second = { name: "Torrentio\nRD+", title: "Second 1080p", url: "https://media.example/second" };
+    expect(firstAcceptableCachedStream([
+      { name: "Torrentio\nRD+", title: "Unsuitable 2160p", url: "https://media.example/4k" }, first, second,
+    ])).toBe(first);
   });
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   plugins: [
     cloudflareTest({
-      wrangler: { configPath: "./wrangler.jsonc" },
+      wrangler: { configPath: "./wrangler.test.jsonc" },
     }),
   ],
 });

--- a/wrangler.test.jsonc
+++ b/wrangler.test.jsonc
@@ -1,17 +1,17 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "kids-channels",
+  "name": "kids-channels-test",
   "main": "src/index.ts",
   "compatibility_date": "2026-07-24",
+  "vars": {
+    "CONFIG_SECRET": "test-only-configuration-secret-at-least-32-characters"
+  },
   "d1_databases": [
     {
       "binding": "DB",
-      "database_name": "kids-channels",
+      "database_name": "kids-channels-test",
       "database_id": "00000000-0000-0000-0000-000000000000",
       "migrations_dir": "migrations"
     }
-  ],
-  "observability": {
-    "enabled": false
-  }
+  ]
 }


### PR DESCRIPTION
## Summary
- add authenticated Parent configuration and replacement flow for Torrentio
- validate the manifest plus a representative stream request and classify cached, unavailable, unsuitable, and provider-failure outcomes
- encrypt provider credentials in D1 with Household-bound AES-GCM and avoid returning or logging provider secrets
- isolate Torrentio behind a stream-provider boundary that preserves ordering and selects the first acceptable cached 1080p direct result
- add outbound-fetch-stubbed Worker tests and a separate credential-safe optional contract probe

## Verification
- `pnpm typecheck`
- `pnpm test`
- `pnpm exec wrangler deploy --dry-run --outdir /tmp/kids-channels-dry-run`

Closes #3
