### PR TITLE
Fix Torrentio validation in the Worker runtime

### DIFF
--- a/src/stream-provider.ts
+++ b/src/stream-provider.ts
@@ -60,7 +60,11 @@ export function parseTorrentioManifestUrl(value: unknown): URL | null {
 }
 
 export class TorrentioProvider implements StreamProvider {
-  constructor(private readonly manifestUrl: URL, private readonly request: typeof fetch = fetch) {}
+  constructor(private readonly manifestUrl: URL, private readonly request?: typeof fetch) {}
+
+  private fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    return this.request ? this.request.call(globalThis, input, init) : fetch(input, init);
+  }
 
   private streamUrl(type: "movie" | "series", id: string): URL {
     const url = new URL(this.manifestUrl);
@@ -69,7 +73,7 @@ export class TorrentioProvider implements StreamProvider {
   }
 
   async streams(type: "movie" | "series", id: string): Promise<ProviderStream[]> {
-    const response = await this.request(this.streamUrl(type, id), {
+    const response = await this.fetch(this.streamUrl(type, id), {
       headers: { accept: "application/json" },
       signal: AbortSignal.timeout(10_000),
     });
@@ -85,7 +89,7 @@ export class TorrentioProvider implements StreamProvider {
 
   async validate(): Promise<ValidationResult> {
     try {
-      const manifestResponse = await this.request(this.manifestUrl, {
+      const manifestResponse = await this.fetch(this.manifestUrl, {
         headers: { accept: "application/json" },
         signal: AbortSignal.timeout(10_000),
       });

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -1,7 +1,7 @@
 import { env, SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { decryptedManifestUrl } from "../src/provider-config";
-import { firstAcceptableCachedStream } from "../src/stream-provider";
+import { firstAcceptableCachedStream, TorrentioProvider } from "../src/stream-provider";
 
 interface CreatedHousehold {
   householdId: string;
@@ -108,7 +108,7 @@ describe("Torrentio configuration", () => {
   const providerOrigin = "https://torrentio.example";
   const providerPath = "/providers=test/realdebrid=REDACTED";
   const manifestUrl = `${providerOrigin}${providerPath}/manifest.json`;
-  const deploymentSecret = "test-only-configuration-secret-at-least-32-characters";
+  const deploymentSecret = (env as typeof env & { CONFIG_SECRET: string }).CONFIG_SECRET;
 
   function mockTorrentio(streams: unknown[], manifestStatus = 200, streamStatus = 200) {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
@@ -206,6 +206,21 @@ describe("Torrentio configuration", () => {
     const body = await unlocked.text();
     expect(JSON.parse(body)).toMatchObject({ provider: { configured: true, validation: { status: "acceptable_cached" } } });
     expect(body).not.toContain("REDACTED");
+  });
+
+  it("invokes an injected outbound fetch with the Worker global receiver", async () => {
+    let requests = 0;
+    const strictFetch = async function (this: unknown): Promise<Response> {
+      if (this !== globalThis) throw new TypeError("fetch called with the wrong receiver");
+      requests += 1;
+      return requests === 1
+        ? Response.json({ id: "org.example.torrentio", resources: ["stream"] })
+        : Response.json({ streams: [] });
+    } as typeof fetch;
+
+    const result = await new TorrentioProvider(new URL(manifestUrl), strictFetch).validate();
+    expect(result.status).toBe("no_cached_result");
+    expect(requests).toBe(2);
   });
 
   it("preserves provider ordering when selecting the first acceptable cached direct stream", () => {


### PR DESCRIPTION
## Root cause
`TorrentioProvider` stored the native Worker `fetch` function and invoked it as a provider object property. Workerd rejects that call because native `fetch` requires the Worker global receiver, producing an `Illegal invocation` before the manifest request receives a response.

## Fix
- invoke outbound fetch directly or with the Worker global receiver
- add a regression test that rejects the previous incorrect receiver
- read the active test deployment secret so local `.dev.vars` cannot invalidate encryption assertions

## Verification
- `pnpm typecheck`
- `pnpm test` (14 passing)
- complete local Worker save/validate flow against the public Torrentio endpoint with a redacted fake credential now returns `no_cached_result` instead of `provider_failure`
