### PR TITLE
Document Workerd fetch receiver requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,14 @@ Use the five canonical triage labels configured for this repository. See `docs/a
 ### Domain docs
 
 This is a single-context repository. See `docs/agents/domain.md`.
+
+## Cloudflare Worker runtime gotcha
+
+Workerd brand-checks native runtime functions such as `fetch`. Do not detach a native function and later invoke it as an object property; for example, storing `fetch` in a provider field and calling `this.request(...)` changes its receiver and throws `Illegal invocation` before any HTTP response exists.
+
+- Call the global function directly: `fetch(input, init)`.
+- When an outbound HTTP function is injected, invoke it with the Worker global receiver: `request.call(globalThis, input, init)`.
+- Add a regression test whose injected function rejects an incorrect `this` receiver.
+- Exercise outbound HTTP through the complete Worker/workerd seam. A Node-only contract probe can succeed while the Worker call still fails.
+
+See `TorrentioProvider` in `src/stream-provider.ts` and its receiver regression test in `test/worker.test.ts`.


### PR DESCRIPTION
Documents the native Worker `fetch` receiver pitfall diagnosed in PR #19, including the safe invocation patterns and required regression-test seam.