### PR TITLE
Search Cinemeta and approve programmes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ npm-debug.log*
 .dev.vars
 .DS_Store
 .pi/
+playwright-report/
+test-results/

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pnpm db:migrate:local
 pnpm dev
 ```
 
-Keep `.dev.vars` private; changing `CONFIG_SECRET` makes existing encrypted provider configurations unreadable. Open `http://localhost:8787`, choose a six-digit Parent PIN, and create a Household. The page returns the opaque manifest URL and a `stremio://` installation action.
+Keep `.dev.vars` private; changing `CONFIG_SECRET` makes existing encrypted provider configurations unreadable. Open `http://localhost:8787`, choose a six-digit Parent PIN, and create a Household. The page returns the opaque manifest URL and a `stremio://` installation action. Open the Parent Page, unlock it, then search Cinemeta to approve shows and movies. Shows default to S01E01; choose another regular released episode before approval when needed.
 
 Local D1 data is stored by Wrangler under `.wrangler/`. There is no forgotten-PIN recovery.
 
@@ -27,9 +27,12 @@ Local D1 data is stored by Wrangler under `.wrangler/`. There is no forgotten-PI
 ```bash
 pnpm typecheck
 pnpm test
+pnpm exec playwright install chromium # once per machine
+pnpm test:browser
+# Or run both suites with: pnpm test:all
 ```
 
-The integration and protocol suite runs the complete creation, PIN unlock, provider validation, encrypted storage, manifest, and catalog flow inside the Cloudflare Worker runtime against an isolated test D1 database. Torrentio is stubbed only at outbound `fetch`; deterministic tests contain no real credentials or signed media URLs.
+The integration and protocol suite runs the complete creation, PIN unlock, provider validation, Cinemeta search, approval, encrypted storage, manifest, and catalog flow inside the Cloudflare Worker runtime against an isolated test D1 database. Cinemeta and Torrentio are stubbed only at outbound `fetch`; deterministic tests contain no real credentials or signed media URLs. The Playwright suite starts a local Worker, local D1 database, and network-boundary Cinemeta stub to exercise the Parent Page in Chromium. Set `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` to use an existing Chromium binary instead of downloading one.
 
 A credential-safe real-provider check is documented separately in [`docs/torrentio-contract-probe.md`](docs/torrentio-contract-probe.md). It is optional and never runs in CI.
 
@@ -58,6 +61,9 @@ The Worker never places the Parent PIN or provider credentials in installation U
 - `GET /households/:secret` — PIN unlock Parent Page
 - `POST /api/households/:secret/unlock` — authenticate a Parent for one hour
 - `PUT /api/households/:secret/provider` — save and validate a Torrentio endpoint (Parent bearer token required)
+- `GET /api/households/:secret/cinemeta/search?q=…` — search Cinemeta shows and movies (Parent bearer token required)
+- `GET /api/households/:secret/cinemeta/title/:type/:imdbId` — retrieve canonical title and released episode metadata (Parent bearer token required)
+- `GET|POST /api/households/:secret/library` — view or add to the Approved Library (Parent bearer token required)
 - `GET /addons/:secret/manifest.json` — Household Stremio manifest
 - `GET /addons/:secret/catalog/tv/kids-tv-channel.json` — one TV Channel tile
 - `GET /addons/:secret/catalog/movie/kids-movie-channel.json` — one Movie Channel tile

--- a/migrations/0003_add_approved_library.sql
+++ b/migrations/0003_add_approved_library.sql
@@ -1,0 +1,38 @@
+CREATE TABLE approved_programmes (
+  id TEXT PRIMARY KEY NOT NULL,
+  household_id TEXT NOT NULL,
+  imdb_id TEXT NOT NULL,
+  content_type TEXT NOT NULL CHECK (content_type IN ('show', 'movie')),
+  title TEXT NOT NULL,
+  description TEXT,
+  poster TEXT,
+  background TEXT,
+  release_info TEXT,
+  genres_json TEXT NOT NULL DEFAULT '[]',
+  imdb_rating TEXT,
+  approved_at TEXT NOT NULL,
+  FOREIGN KEY (household_id) REFERENCES households(id) ON DELETE CASCADE,
+  UNIQUE (household_id, content_type, imdb_id)
+);
+
+CREATE INDEX approved_programmes_household_idx
+  ON approved_programmes (household_id, approved_at);
+
+CREATE TABLE show_episodes (
+  programme_id TEXT NOT NULL,
+  video_id TEXT NOT NULL,
+  season INTEGER NOT NULL,
+  episode INTEGER NOT NULL,
+  title TEXT NOT NULL,
+  released_at TEXT NOT NULL,
+  overview TEXT,
+  PRIMARY KEY (programme_id, video_id),
+  FOREIGN KEY (programme_id) REFERENCES approved_programmes(id) ON DELETE CASCADE,
+  UNIQUE (programme_id, season, episode)
+);
+
+CREATE TABLE show_progress (
+  programme_id TEXT PRIMARY KEY NOT NULL,
+  next_video_id TEXT NOT NULL,
+  FOREIGN KEY (programme_id) REFERENCES approved_programmes(id) ON DELETE CASCADE
+);

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "probe:torrentio": "node scripts/probe-torrentio.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:browser": "playwright test",
+    "test:all": "pnpm test && pnpm test:browser",
     "typecheck": "tsc"
   },
   "keywords": [
@@ -22,6 +24,7 @@
   "license": "MIT",
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "~0.18.8",
+    "@playwright/test": "^1.61.1",
     "typescript": "^7.0.2",
     "vitest": "~4.1.10",
     "wrangler": "^4.114.0"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./test/browser",
+  fullyParallel: false,
+  workers: 1,
+  use: {
+    baseURL: "http://127.0.0.1:8790",
+    trace: "retain-on-failure",
+    launchOptions: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+      ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH }
+      : undefined,
+  },
+  webServer: {
+    command: "node scripts/start-browser-test-server.mjs",
+    url: "http://127.0.0.1:8790",
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@cloudflare/vitest-pool-workers':
         specifier: ~0.18.8
         version: 0.18.8(@cloudflare/workers-types@5.20260724.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10(vite@7.3.6))
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -395,6 +398,11 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
 
@@ -749,6 +757,11 @@ packages:
       picomatch:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -787,6 +800,16 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.22:
     resolution: {integrity: sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==}
@@ -1220,6 +1243,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
+
   '@poppinss/colors@4.1.6':
     dependencies:
       kleur: 4.1.5
@@ -1480,6 +1507,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -1512,6 +1542,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.22:
     dependencies:

--- a/scripts/start-browser-test-server.mjs
+++ b/scripts/start-browser-test-server.mjs
@@ -1,0 +1,39 @@
+import { spawn, spawnSync } from "node:child_process";
+import http from "node:http";
+
+const show = {
+  id: "tt1234567", imdb_id: "tt1234567", type: "series", name: "The Example",
+  description: "A recognisable family show.", poster: "https://placehold.co/300x450?text=Example+Show",
+  releaseInfo: "2020–", genres: ["Family", "Animation"], imdbRating: "8.4",
+  videos: [
+    { id: "tt1234567:0:1", season: 0, episode: 1, title: "Special", released: "2019-12-01T00:00:00.000Z" },
+    { id: "tt1234567:1:1", season: 1, episode: 1, title: "First", released: "2020-01-01T00:00:00.000Z" },
+    { id: "tt1234567:1:2", season: 1, episode: 2, title: "Second", released: "2020-01-08T00:00:00.000Z" },
+    { id: "tt1234567:1:3", season: 1, episode: 3, title: "Unreleased", released: "2999-01-01T00:00:00.000Z" },
+  ],
+};
+const movie = {
+  id: "tt7654321", imdb_id: "tt7654321", type: "movie", name: "Example: The Movie",
+  description: "A family film.", poster: "https://placehold.co/300x450?text=Example+Movie",
+  releaseInfo: "2022", genres: ["Family"], imdbRating: "7.1",
+};
+
+const stub = http.createServer((request, response) => {
+  let body;
+  if (request.url?.startsWith("/catalog/series/top/search=")) {
+    body = { metas: [show, { ...show, id: "tt1111111", imdb_id: "tt1111111", name: "The Example (1990)", releaseInfo: "1990" }] };
+  } else if (request.url?.startsWith("/catalog/movie/top/search=")) body = { metas: [movie] };
+  else if (request.url === "/meta/series/tt1234567.json") body = { meta: show };
+  else if (request.url === "/meta/movie/tt7654321.json") body = { meta: movie };
+  else { response.writeHead(404); response.end(); return; }
+  response.writeHead(200, { "content-type": "application/json" }); response.end(JSON.stringify(body));
+});
+await new Promise((resolve) => stub.listen(8791, "127.0.0.1", resolve));
+
+const migration = spawnSync("pnpm", ["exec", "wrangler", "d1", "migrations", "apply", "kids-channels-browser", "--local", "--config", "wrangler.browser.jsonc"], { stdio: "inherit" });
+if (migration.status !== 0) process.exit(migration.status ?? 1);
+const worker = spawn("pnpm", ["exec", "wrangler", "dev", "--config", "wrangler.browser.jsonc", "--port", "8790", "--ip", "127.0.0.1"], { stdio: "inherit" });
+
+function stop() { worker.kill("SIGTERM"); stub.close(); }
+process.on("SIGINT", stop); process.on("SIGTERM", stop);
+worker.on("exit", (code) => { stub.close(); process.exit(code ?? 0); });

--- a/src/approved-library.ts
+++ b/src/approved-library.ts
@@ -1,0 +1,125 @@
+import type { CinemetaEpisode, CinemetaShow, CinemetaTitle, ContentType } from "./cinemeta";
+
+export interface ApprovedProgramme {
+  id: string;
+  imdbId: string;
+  type: ContentType;
+  title: string;
+  description?: string;
+  poster?: string;
+  background?: string;
+  releaseInfo?: string;
+  genres: string[];
+  imdbRating?: string;
+  approvedAt: string;
+  episodes?: CinemetaEpisode[];
+  showProgress?: CinemetaEpisode;
+}
+
+interface StoredProgramme {
+  id: string;
+  imdb_id: string;
+  content_type: ContentType;
+  title: string;
+  description: string | null;
+  poster: string | null;
+  background: string | null;
+  release_info: string | null;
+  genres_json: string;
+  imdb_rating: string | null;
+  approved_at: string;
+  next_video_id: string | null;
+}
+
+function episodeFromRow(row: Record<string, unknown>): CinemetaEpisode {
+  return {
+    id: row.video_id as string,
+    season: row.season as number,
+    episode: row.episode as number,
+    title: row.title as string,
+    released: row.released_at as string,
+    overview: (row.overview as string | null) ?? undefined,
+  };
+}
+
+function programmeFromRow(row: StoredProgramme): ApprovedProgramme {
+  return {
+    id: row.id,
+    imdbId: row.imdb_id,
+    type: row.content_type,
+    title: row.title,
+    description: row.description ?? undefined,
+    poster: row.poster ?? undefined,
+    background: row.background ?? undefined,
+    releaseInfo: row.release_info ?? undefined,
+    genres: JSON.parse(row.genres_json) as string[],
+    imdbRating: row.imdb_rating ?? undefined,
+    approvedAt: row.approved_at,
+  };
+}
+
+export async function hasApprovedProgramme(
+  db: D1Database,
+  householdId: string,
+  type: ContentType,
+  imdbId: string,
+): Promise<boolean> {
+  return Boolean(await db.prepare(
+    "SELECT 1 AS found FROM approved_programmes WHERE household_id = ? AND content_type = ? AND imdb_id = ?",
+  ).bind(householdId, type, imdbId).first());
+}
+
+export async function approveProgramme(
+  db: D1Database,
+  householdId: string,
+  title: CinemetaTitle | CinemetaShow,
+  startingEpisodeId?: string,
+): Promise<ApprovedProgramme> {
+  const id = crypto.randomUUID();
+  const approvedAt = new Date().toISOString();
+  const statements = [db.prepare(`INSERT INTO approved_programmes
+    (id, household_id, imdb_id, content_type, title, description, poster, background, release_info, genres_json, imdb_rating, approved_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+    .bind(id, householdId, title.id, title.type, title.title, title.description ?? null, title.poster ?? null,
+      title.background ?? null, title.releaseInfo ?? null, JSON.stringify(title.genres), title.imdbRating ?? null, approvedAt)];
+
+  let startingEpisode: CinemetaEpisode | undefined;
+  if (title.type === "show") {
+    const show = title as CinemetaShow;
+    if (show.episodes.length === 0) throw new Error("show has no regular released episodes");
+    startingEpisode = startingEpisodeId
+      ? show.episodes.find((episode) => episode.id === startingEpisodeId)
+      : show.episodes.find((episode) => episode.season === 1 && episode.episode === 1);
+    if (!startingEpisode) throw new Error("starting episode is invalid");
+    for (const episode of show.episodes) {
+      statements.push(db.prepare(`INSERT INTO show_episodes
+        (programme_id, video_id, season, episode, title, released_at, overview) VALUES (?, ?, ?, ?, ?, ?, ?)`)
+        .bind(id, episode.id, episode.season, episode.episode, episode.title, episode.released, episode.overview ?? null));
+    }
+    statements.push(db.prepare("INSERT INTO show_progress (programme_id, next_video_id) VALUES (?, ?)")
+      .bind(id, startingEpisode.id));
+  }
+
+  await db.batch(statements);
+  return { ...title, id, imdbId: title.id, approvedAt, showProgress: startingEpisode };
+}
+
+export async function approvedLibrary(db: D1Database, householdId: string): Promise<ApprovedProgramme[]> {
+  const rows = await db.prepare(`SELECT p.*, progress.next_video_id
+    FROM approved_programmes p
+    LEFT JOIN show_progress progress ON progress.programme_id = p.id
+    WHERE p.household_id = ? ORDER BY p.approved_at, p.title`).bind(householdId).all<StoredProgramme>();
+
+  const programmes: ApprovedProgramme[] = [];
+  for (const row of rows.results) {
+    const programme = programmeFromRow(row);
+    if (programme.type === "show") {
+      const episodeRows = await db.prepare(`SELECT video_id, season, episode, title, released_at, overview
+        FROM show_episodes WHERE programme_id = ? ORDER BY season, episode`).bind(programme.id).all<Record<string, unknown>>();
+      programme.episodes = episodeRows.results.map(episodeFromRow);
+      programme.showProgress = programme.episodes.find((episode) => episode.id === row.next_video_id);
+    }
+    programmes.push(programme);
+  }
+  return programmes;
+}

--- a/src/cinemeta.ts
+++ b/src/cinemeta.ts
@@ -1,0 +1,122 @@
+export type ContentType = "show" | "movie";
+
+export interface CinemetaTitle {
+  id: string;
+  type: ContentType;
+  title: string;
+  description?: string;
+  poster?: string;
+  background?: string;
+  releaseInfo?: string;
+  genres: string[];
+  imdbRating?: string;
+}
+
+export interface CinemetaEpisode {
+  id: string;
+  season: number;
+  episode: number;
+  title: string;
+  released: string;
+  overview?: string;
+}
+
+export interface CinemetaShow extends CinemetaTitle {
+  type: "show";
+  episodes: CinemetaEpisode[];
+}
+
+type CinemetaMeta = Record<string, unknown>;
+
+const IMDB_ID = /^tt\d+$/;
+
+function text(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function titleFrom(meta: CinemetaMeta, type: ContentType): CinemetaTitle | null {
+  const id = text(meta.imdb_id) ?? text(meta.id);
+  const title = text(meta.name);
+  if (!id || !IMDB_ID.test(id) || !title) return null;
+  return {
+    id,
+    type,
+    title,
+    description: text(meta.description),
+    poster: text(meta.poster),
+    background: text(meta.background),
+    releaseInfo: text(meta.releaseInfo) ?? text(meta.year),
+    genres: Array.isArray(meta.genres) ? meta.genres.filter((genre): genre is string => typeof genre === "string") : [],
+    imdbRating: text(meta.imdbRating),
+  };
+}
+
+function regularReleasedEpisodes(meta: CinemetaMeta, imdbId: string, now: number): CinemetaEpisode[] {
+  if (!Array.isArray(meta.videos)) return [];
+  return meta.videos.flatMap((value): CinemetaEpisode[] => {
+    if (typeof value !== "object" || value === null) return [];
+    const video = value as CinemetaMeta;
+    const id = text(video.id);
+    const season = video.season;
+    const episode = video.episode;
+    const title = text(video.title) ?? text(video.name);
+    const released = text(video.released);
+    const releasedAt = released ? Date.parse(released) : Number.NaN;
+    if (
+      !id || !id.startsWith(`${imdbId}:`) || !Number.isInteger(season) || !Number.isInteger(episode)
+      || (season as number) < 1 || (episode as number) < 1 || !title || !released
+      || !Number.isFinite(releasedAt) || releasedAt > now
+    ) return [];
+    return [{ id, season: season as number, episode: episode as number, title, released, overview: text(video.overview) }];
+  }).sort((left, right) => left.season - right.season || left.episode - right.episode);
+}
+
+export class CinemetaClient {
+  constructor(
+    private readonly origin = "https://v3-cinemeta.strem.io",
+    private readonly request?: typeof fetch,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  private fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    return this.request ? this.request.call(globalThis, input, init) : fetch(input, init);
+  }
+
+  private async json(path: string): Promise<CinemetaMeta> {
+    const response = await this.fetch(new URL(path, this.origin), {
+      headers: { accept: "application/json" },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) throw new Error(response.status === 404 ? "cinemeta title not found" : "cinemeta request failed");
+    const body: unknown = await response.json();
+    if (typeof body !== "object" || body === null) throw new Error("cinemeta response invalid");
+    return body as CinemetaMeta;
+  }
+
+  async search(query: string): Promise<CinemetaTitle[]> {
+    const encoded = encodeURIComponent(query);
+    const [shows, movies] = await Promise.all([
+      this.json(`/catalog/series/top/search=${encoded}.json`),
+      this.json(`/catalog/movie/top/search=${encoded}.json`),
+    ]);
+    const normalize = (body: CinemetaMeta, type: ContentType) =>
+      (Array.isArray(body.metas) ? body.metas : []).flatMap((meta): CinemetaTitle[] => {
+        if (typeof meta !== "object" || meta === null) return [];
+        const normalized = titleFrom(meta as CinemetaMeta, type);
+        return normalized ? [normalized] : [];
+      });
+    return [...normalize(shows, "show"), ...normalize(movies, "movie")];
+  }
+
+  async title(type: ContentType, imdbId: string): Promise<CinemetaTitle | CinemetaShow | null> {
+    if (!IMDB_ID.test(imdbId)) return null;
+    const resourceType = type === "show" ? "series" : "movie";
+    const body = await this.json(`/meta/${resourceType}/${imdbId}.json`);
+    if (typeof body.meta !== "object" || body.meta === null) return null;
+    const meta = body.meta as CinemetaMeta;
+    const normalized = titleFrom(meta, type);
+    if (!normalized || normalized.id !== imdbId) return null;
+    if (type === "movie") return normalized;
+    return { ...normalized, type: "show", episodes: regularReleasedEpisodes(meta, imdbId, this.now()) };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import { approveProgramme, approvedLibrary, hasApprovedProgramme } from "./approved-library";
+import { CinemetaClient, type ContentType } from "./cinemeta";
 import { createHousehold, findHousehold, validPin, verifyPin } from "./households";
 import { providerConfiguration, saveProviderConfiguration } from "./provider-config";
 import { issueParentToken, verifyParentToken } from "./secrets";
@@ -7,6 +9,7 @@ import { catalogFor, manifestFor } from "./stremio";
 export interface Env {
   DB: D1Database;
   CONFIG_SECRET?: string;
+  CINEMETA_ORIGIN?: string;
 }
 
 const jsonHeaders = {
@@ -23,7 +26,7 @@ function html(body: string, status = 200): Response {
     status,
     headers: {
       "content-type": "text/html; charset=utf-8",
-      "content-security-policy": "default-src 'self'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; base-uri 'none'; frame-ancestors 'none'",
+      "content-security-policy": "default-src 'self'; img-src 'self' https: data:; style-src 'unsafe-inline'; script-src 'unsafe-inline'; base-uri 'none'; frame-ancestors 'none'",
       "x-content-type-options": "nosniff",
     },
   });
@@ -42,14 +45,19 @@ function shell(content: string, title = "Kids Channels"): string {
     main { width: min(34rem, calc(100% - 2rem)); background: #1b2140; border: 1px solid #343c69; border-radius: 1rem; padding: clamp(1.25rem, 5vw, 2.5rem); box-shadow: 0 1.5rem 5rem #080a14; }
     h1 { margin-top: 0; } p { line-height: 1.55; color: #cbd0ea; }
     label { display: block; font-weight: 700; margin: 1.5rem 0 .5rem; }
-    input, button, .button { box-sizing: border-box; width: 100%; min-height: 3rem; border-radius: .6rem; border: 1px solid #566098; padding: .7rem 1rem; font: inherit; }
-    input { background: #0e1224; color: white; font-size: 1.25rem; }
+    input, select, button, .button { box-sizing: border-box; width: 100%; min-height: 3rem; border-radius: .6rem; border: 1px solid #566098; padding: .7rem 1rem; font: inherit; }
+    input, select { background: #0e1224; color: white; font-size: 1.1rem; }
     input[name="pin"] { letter-spacing: .2em; }
     button, .button { display: block; cursor: pointer; background: #725cff; border-color: #8c7aff; color: white; font-weight: 800; text-align: center; text-decoration: none; margin-top: 1rem; }
     .secondary { background: transparent; }
     .notice { border-left: .25rem solid #ffca5c; padding-left: 1rem; }
     .error { color: #ff9292; min-height: 1.5rem; }
     code { overflow-wrap: anywhere; color: #aeb8ff; }
+    .programme { display: grid; grid-template-columns: 5rem 1fr; gap: 1rem; margin: 1rem 0; padding: 1rem; border: 1px solid #343c69; border-radius: .75rem; }
+    .programme img { width: 5rem; min-height: 7rem; object-fit: cover; border-radius: .35rem; background: #0e1224; }
+    .programme h3 { margin: 0; } .programme p { margin: .35rem 0; }
+    .programme button { width: auto; min-height: 2.5rem; margin-top: .5rem; }
+    .eyebrow { color: #65d6ad; font-size: .8rem; font-weight: 800; text-transform: uppercase; }
     [hidden] { display: none !important; }
   </style>
 </head>
@@ -119,6 +127,15 @@ function parentPage(secret: string): string {
       <h2>Household unlocked</h2>
       <a id="install" class="button" href="#">Install in Stremio</a>
       <p>Manifest: <code id="manifest"></code></p>
+      <form id="search-form">
+        <label for="search">Search Cinemeta for shows and movies</label>
+        <input id="search" name="query" type="search" minlength="2" maxlength="100" placeholder="Bluey, Paddington…" required>
+        <button type="submit">Search</button>
+        <p id="search-status" role="status"></p>
+      </form>
+      <div id="search-results"></div>
+      <h2>Approved Library</h2>
+      <div id="library"><p>No programmes approved yet.</p></div>
       <form id="provider-form">
         <label for="manifest-url">Torrentio manifest URL</label>
         <input id="manifest-url" name="manifestUrl" type="url" placeholder="https://…/manifest.json" autocomplete="off" required>
@@ -129,35 +146,80 @@ function parentPage(secret: string): string {
     </section>
     <script>
       const form = document.querySelector('#unlock-form');
+      const headers = () => ({authorization: 'Bearer ' + parentToken});
       let parentToken = '';
+      function programmeCard(programme, approved) {
+        const card = document.createElement('article'); card.className = 'programme';
+        const image = document.createElement('img'); image.alt = ''; if (programme.poster) image.src = programme.poster;
+        const details = document.createElement('div');
+        const kind = document.createElement('div'); kind.className = 'eyebrow'; kind.textContent = programme.type === 'show' ? 'Show' : 'Movie';
+        const heading = document.createElement('h3'); heading.textContent = programme.title;
+        const metadata = document.createElement('p'); metadata.textContent = [programme.releaseInfo, (programme.genres || []).join(', '), programme.imdbRating ? 'IMDb ' + programme.imdbRating : ''].filter(Boolean).join(' · ');
+        const description = document.createElement('p'); description.textContent = programme.description || 'No description available.';
+        details.append(kind, heading, metadata, description);
+        if (approved && programme.showProgress) {
+          const progress = document.createElement('p'); progress.textContent = 'Starts at S' + String(programme.showProgress.season).padStart(2, '0') + 'E' + String(programme.showProgress.episode).padStart(2, '0') + ' — ' + programme.showProgress.title;
+          details.append(progress);
+        }
+        card.append(image, details); return {card, details};
+      }
+      async function loadLibrary() {
+        const response = await fetch('/api/households/${secret}/library', {headers: headers()});
+        const result = await response.json(); const output = document.querySelector('#library'); output.replaceChildren();
+        if (!result.programmes.length) { const empty = document.createElement('p'); empty.textContent = 'No programmes approved yet.'; output.append(empty); return; }
+        result.programmes.forEach(programme => output.append(programmeCard(programme, true).card));
+      }
+      async function approve(programme, startingEpisodeId, button) {
+        button.disabled = true;
+        const response = await fetch('/api/households/${secret}/library', {
+          method: 'POST', headers: {...headers(), 'content-type': 'application/json'},
+          body: JSON.stringify({type: programme.type, imdbId: programme.id, startingEpisodeId})
+        });
+        const result = await response.json();
+        if (!response.ok) { button.disabled = false; button.textContent = result.error; return; }
+        button.textContent = 'Approved'; await loadLibrary();
+      }
+      function showSearchResult(programme) {
+        const built = programmeCard(programme, false); const button = document.createElement('button');
+        button.type = 'button'; button.textContent = programme.type === 'show' ? 'Choose starting episode' : 'Approve movie';
+        button.addEventListener('click', async () => {
+          if (programme.type === 'movie') return approve(programme, undefined, button);
+          button.disabled = true; button.textContent = 'Loading episodes…';
+          const response = await fetch('/api/households/${secret}/cinemeta/title/show/' + encodeURIComponent(programme.id), {headers: headers()});
+          const result = await response.json();
+          if (!response.ok) { button.disabled = false; button.textContent = result.error; return; }
+          const select = document.createElement('select'); select.setAttribute('aria-label', 'Starting episode for ' + programme.title);
+          result.title.episodes.forEach(episode => { const option = document.createElement('option'); option.value = episode.id; option.textContent = 'S' + String(episode.season).padStart(2, '0') + 'E' + String(episode.episode).padStart(2, '0') + ' — ' + episode.title; select.append(option); });
+          button.disabled = false; button.textContent = 'Approve show'; button.replaceWith(select, button);
+          button.addEventListener('click', () => approve(programme, select.value, button), {once: true});
+        }, {once: programme.type === 'show'});
+        built.details.append(button); return built.card;
+      }
       form.addEventListener('submit', async (event) => {
         event.preventDefault();
         const response = await fetch('/api/households/${secret}/unlock', {
-          method: 'POST', headers: {'content-type': 'application/json'},
-          body: JSON.stringify({pin: new FormData(form).get('pin')})
+          method: 'POST', headers: {'content-type': 'application/json'}, body: JSON.stringify({pin: new FormData(form).get('pin')})
         });
         const result = await response.json();
         if (!response.ok) { document.querySelector('#error').textContent = result.error; return; }
-        parentToken = result.parentToken;
-        document.querySelector('#install').href = result.installUrl;
+        parentToken = result.parentToken; document.querySelector('#install').href = result.installUrl;
         document.querySelector('#manifest').textContent = result.manifestUrl;
-        document.querySelector('#provider-result').textContent = result.provider.configured
-          ? result.provider.validation.message + ' Enter a new URL to replace it.' : 'Torrentio is not configured.';
-        form.hidden = true;
-        document.querySelector('#result').hidden = false;
+        document.querySelector('#provider-result').textContent = result.provider.configured ? result.provider.validation.message + ' Enter a new URL to replace it.' : 'Torrentio is not configured.';
+        form.hidden = true; document.querySelector('#result').hidden = false; await loadLibrary();
+      });
+      document.querySelector('#search-form').addEventListener('submit', async (event) => {
+        event.preventDefault(); const status = document.querySelector('#search-status'); status.textContent = 'Searching Cinemeta…';
+        const query = new FormData(event.currentTarget).get('query');
+        const response = await fetch('/api/households/${secret}/cinemeta/search?q=' + encodeURIComponent(query), {headers: headers()});
+        const result = await response.json(); const output = document.querySelector('#search-results'); output.replaceChildren();
+        if (!response.ok) { status.textContent = result.error; return; }
+        status.textContent = result.results.length ? result.results.length + ' results' : 'No matching shows or movies.';
+        result.results.forEach(programme => output.append(showSearchResult(programme)));
       });
       document.querySelector('#provider-form').addEventListener('submit', async (event) => {
-        event.preventDefault();
-        const output = document.querySelector('#provider-result');
-        output.textContent = 'Checking Torrentio manifest and a representative stream…';
-        const response = await fetch('/api/households/${secret}/provider', {
-          method: 'PUT',
-          headers: {'content-type': 'application/json', authorization: 'Bearer ' + parentToken},
-          body: JSON.stringify({manifestUrl: new FormData(event.currentTarget).get('manifestUrl')})
-        });
-        const result = await response.json();
-        output.textContent = response.ok ? result.validation.message : result.error;
-        if (response.ok) event.currentTarget.reset();
+        event.preventDefault(); const output = document.querySelector('#provider-result'); output.textContent = 'Checking Torrentio manifest and a representative stream…';
+        const response = await fetch('/api/households/${secret}/provider', { method: 'PUT', headers: {...headers(), 'content-type': 'application/json'}, body: JSON.stringify({manifestUrl: new FormData(event.currentTarget).get('manifestUrl')}) });
+        const result = await response.json(); output.textContent = response.ok ? result.validation.message : result.error; if (response.ok) event.currentTarget.reset();
       });
     </script>`);
 }
@@ -237,6 +299,66 @@ export default {
       const validation = await new TorrentioProvider(manifestUrl).validate();
       const saved = await saveProviderConfiguration(env.DB, household.id, manifestUrl.toString(), env.CONFIG_SECRET, validation);
       return json(saved);
+    }
+
+    const searchMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/cinemeta\/search$/);
+    if (request.method === "GET" && searchMatch) {
+      const household = await findHousehold(env.DB, searchMatch[1]);
+      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household.id, env.CONFIG_SECRET))) {
+        return json({ error: "Parent authentication is required." }, 401);
+      }
+      const query = url.searchParams.get("q")?.trim();
+      if (!query || query.length < 2 || query.length > 100) return json({ error: "Search must contain between 2 and 100 characters." }, 400);
+      try {
+        return json({ results: await new CinemetaClient(env.CINEMETA_ORIGIN).search(query) });
+      } catch {
+        return json({ error: "Cinemeta search is temporarily unavailable." }, 502);
+      }
+    }
+
+    const titleMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/cinemeta\/title\/(show|movie)\/(tt\d+)$/);
+    if (request.method === "GET" && titleMatch) {
+      const household = await findHousehold(env.DB, titleMatch[1]);
+      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household.id, env.CONFIG_SECRET))) {
+        return json({ error: "Parent authentication is required." }, 401);
+      }
+      try {
+        const title = await new CinemetaClient(env.CINEMETA_ORIGIN).title(titleMatch[2] as ContentType, titleMatch[3]);
+        if (!title) return json({ error: "Programme was not found in Cinemeta." }, 404);
+        return json({ title });
+      } catch {
+        return json({ error: "Cinemeta metadata is temporarily unavailable." }, 502);
+      }
+    }
+
+    const libraryMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/library$/);
+    if (libraryMatch && (request.method === "GET" || request.method === "POST")) {
+      const household = await findHousehold(env.DB, libraryMatch[1]);
+      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household.id, env.CONFIG_SECRET))) {
+        return json({ error: "Parent authentication is required." }, 401);
+      }
+      if (request.method === "GET") return json({ programmes: await approvedLibrary(env.DB, household.id) });
+      let input: { type?: unknown; imdbId?: unknown; startingEpisodeId?: unknown } = {};
+      try { input = await request.json() as typeof input; } catch { /* handled below */ }
+      if ((input.type !== "show" && input.type !== "movie") || typeof input.imdbId !== "string" || !/^tt\d+$/.test(input.imdbId)
+        || (input.startingEpisodeId !== undefined && typeof input.startingEpisodeId !== "string")) {
+        return json({ error: "Choose a valid Cinemeta show or movie." }, 400);
+      }
+      if (await hasApprovedProgramme(env.DB, household.id, input.type, input.imdbId)) {
+        return json({ error: "This programme is already in the Approved Library." }, 409);
+      }
+      try {
+        const title = await new CinemetaClient(env.CINEMETA_ORIGIN).title(input.type, input.imdbId);
+        if (!title) return json({ error: "Programme was not found in Cinemeta." }, 404);
+        const programme = await approveProgramme(env.DB, household.id, title, input.startingEpisodeId);
+        return json({ programme }, 201);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "";
+        if (message === "starting episode is invalid") return json({ error: "Choose a valid regular released starting episode." }, 400);
+        if (message === "show has no regular released episodes") return json({ error: "This show has no regular released episodes to approve." }, 400);
+        if (message.includes("UNIQUE")) return json({ error: "This programme is already in the Approved Library." }, 409);
+        return json({ error: "Cinemeta metadata is temporarily unavailable." }, 502);
+      }
     }
 
     const parentMatch = path.match(/^\/households\/([A-Za-z0-9_-]+)$/);

--- a/test/browser/approved-library.spec.ts
+++ b/test/browser/approved-library.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+
+test("a Parent searches Cinemeta and approves a movie and a show from another starting episode", async ({ page }) => {
+  await page.goto("/");
+  await page.getByLabel("Choose a six-digit Parent PIN").fill("123456");
+  await page.getByRole("button", { name: "Create Household" }).click();
+  const parentUrl = await page.getByRole("link", { name: "Open Parent Page" }).getAttribute("href");
+  expect(parentUrl).toBeTruthy();
+
+  await page.goto(parentUrl!);
+  await page.getByLabel("Parent PIN").fill("123456");
+  await page.getByRole("button", { name: "Unlock Household" }).click();
+  await expect(page.getByRole("heading", { name: "Approved Library" })).toBeVisible();
+
+  const search = async () => {
+    await page.getByLabel("Search Cinemeta for shows and movies").fill("Example");
+    await page.getByRole("button", { name: "Search", exact: true }).click();
+    await expect(page.locator("#search-results .programme")).toHaveCount(3);
+  };
+  await search();
+
+  const movie = page.locator("#search-results .programme").filter({ hasText: "Example: The Movie" });
+  await expect(movie).toContainText("2022 · Family · IMDb 7.1");
+  await movie.getByRole("button", { name: "Approve movie" }).click();
+  await expect(page.locator("#library .programme").filter({ hasText: "Example: The Movie" })).toBeVisible();
+
+  await search();
+  const duplicateMovie = page.locator("#search-results .programme").filter({ hasText: "Example: The Movie" });
+  await duplicateMovie.getByRole("button", { name: "Approve movie" }).click();
+  await expect(duplicateMovie.getByRole("button")).toHaveText(/already in the Approved Library/);
+  await expect(page.locator("#library .programme").filter({ hasText: "Example: The Movie" })).toHaveCount(1);
+
+  const show = page.locator("#search-results .programme").filter({ hasText: "The Example2020" });
+  await show.getByRole("button", { name: "Choose starting episode" }).click();
+  const startingEpisode = show.getByRole("combobox", { name: "Starting episode for The Example" });
+  await expect(startingEpisode.locator("option")).toHaveCount(2);
+  await expect(startingEpisode.locator("option").first()).toContainText("S01E01 — First");
+  await startingEpisode.selectOption("tt1234567:1:2");
+  await show.getByRole("button", { name: "Approve show" }).click();
+
+  const approvedShow = page.locator("#library .programme").filter({ hasText: "The Example" });
+  await expect(approvedShow).toContainText("Starts at S01E02 — Second");
+});

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -22,7 +22,24 @@ beforeEach(async () => {
     torrentio_validation_status TEXT,
     torrentio_configured_at TEXT
   )`).run();
+  await env.DB.prepare(`CREATE TABLE IF NOT EXISTS approved_programmes (
+    id TEXT PRIMARY KEY NOT NULL, household_id TEXT NOT NULL, imdb_id TEXT NOT NULL,
+    content_type TEXT NOT NULL, title TEXT NOT NULL, description TEXT, poster TEXT, background TEXT,
+    release_info TEXT, genres_json TEXT NOT NULL DEFAULT '[]', imdb_rating TEXT, approved_at TEXT NOT NULL,
+    UNIQUE (household_id, content_type, imdb_id)
+  )`).run();
+  await env.DB.prepare(`CREATE TABLE IF NOT EXISTS show_episodes (
+    programme_id TEXT NOT NULL, video_id TEXT NOT NULL, season INTEGER NOT NULL, episode INTEGER NOT NULL,
+    title TEXT NOT NULL, released_at TEXT NOT NULL, overview TEXT,
+    PRIMARY KEY (programme_id, video_id), UNIQUE (programme_id, season, episode)
+  )`).run();
+  await env.DB.prepare(`CREATE TABLE IF NOT EXISTS show_progress (
+    programme_id TEXT PRIMARY KEY NOT NULL, next_video_id TEXT NOT NULL
+  )`).run();
   await env.DB.prepare("CREATE INDEX IF NOT EXISTS households_secret_idx ON households (secret)").run();
+  await env.DB.prepare("DELETE FROM show_progress").run();
+  await env.DB.prepare("DELETE FROM show_episodes").run();
+  await env.DB.prepare("DELETE FROM approved_programmes").run();
   await env.DB.prepare("DELETE FROM households").run();
   vi.restoreAllMocks();
 });
@@ -229,6 +246,109 @@ describe("Torrentio configuration", () => {
     expect(firstAcceptableCachedStream([
       { name: "Torrentio\nRD+", title: "Unsuitable 2160p", url: "https://media.example/4k" }, first, second,
     ])).toBe(first);
+  });
+});
+
+describe("Cinemeta Approved Library", () => {
+  const showMeta = {
+    id: "tt1234567", imdb_id: "tt1234567", type: "series", name: "The Example",
+    description: "A recognisable family show.", poster: "https://images.example/show.jpg",
+    background: "https://images.example/show-background.jpg", releaseInfo: "2020–", genres: ["Family", "Animation"], imdbRating: "8.4",
+    videos: [
+      { id: "tt1234567:0:1", season: 0, episode: 1, title: "Special", released: "2019-12-01T00:00:00.000Z" },
+      { id: "tt1234567:1:1", season: 1, episode: 1, title: "First", released: "2020-01-01T00:00:00.000Z" },
+      { id: "tt1234567:1:2", season: 1, episode: 2, title: "Second", released: "2020-01-08T00:00:00.000Z" },
+      { id: "tt1234567:1:3", season: 1, episode: 3, title: "Unreleased", released: "2999-01-01T00:00:00.000Z" },
+    ],
+  };
+  const movieMeta = {
+    id: "tt7654321", imdb_id: "tt7654321", type: "movie", name: "Example: The Movie",
+    description: "A family film.", poster: "https://images.example/movie.jpg", releaseInfo: "2022", genres: ["Family"], imdbRating: "7.1",
+  };
+
+  function mockCinemeta() {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const path = new URL(input instanceof Request ? input.url : input.toString()).pathname;
+      if (path.startsWith("/catalog/series/top/search=")) return Response.json({ metas: [showMeta, { ...showMeta, id: "tt1111111", imdb_id: "tt1111111", name: "The Example (1990)", releaseInfo: "1990" }] });
+      if (path.startsWith("/catalog/movie/top/search=")) return Response.json({ metas: [movieMeta] });
+      if (path === "/meta/series/tt1234567.json") return Response.json({ meta: showMeta });
+      if (path === "/meta/movie/tt7654321.json") return Response.json({ meta: movieMeta });
+      return Response.json({}, { status: 404 });
+    });
+  }
+
+  async function parentAccess(created: CreatedHousehold) {
+    const response = await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/unlock`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ pin: "123456" }),
+    });
+    const { parentToken } = await response.json<{ parentToken: string }>();
+    return { authorization: `Bearer ${parentToken}` };
+  }
+
+  it("searches shows and movies with distinguishing metadata and artwork", async () => {
+    const created = await create();
+    const denied = await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/cinemeta/search?q=Example`);
+    expect(denied.status).toBe(401);
+
+    mockCinemeta();
+    const response = await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/cinemeta/search?q=Example`, { headers: await parentAccess(created) });
+    const body = await response.json<any>();
+    expect(response.status).toBe(200);
+    expect(body.results).toHaveLength(3);
+    expect(body.results).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "tt1234567", type: "show", title: "The Example", poster: "https://images.example/show.jpg", releaseInfo: "2020–", genres: ["Family", "Animation"] }),
+      expect.objectContaining({ id: "tt7654321", type: "movie", title: "Example: The Movie", description: "A family film." }),
+    ]));
+  });
+
+  it("approves a show with regular released episodes and defaults Show Progress to S01E01", async () => {
+    const created = await create(); const headers = await parentAccess(created); mockCinemeta();
+    const response = await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/library`, {
+      method: "POST", headers: { ...headers, "content-type": "application/json" },
+      body: JSON.stringify({ type: "show", imdbId: "tt1234567" }),
+    });
+    const approved = await response.json<any>();
+    expect(response.status).toBe(201);
+    expect(approved.programme).toMatchObject({ imdbId: "tt1234567", type: "show", showProgress: { id: "tt1234567:1:1", season: 1, episode: 1 } });
+
+    const library = await (await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/library`, { headers })).json<any>();
+    expect(library.programmes).toHaveLength(1);
+    expect(library.programmes[0].episodes.map((episode: any) => episode.id)).toEqual(["tt1234567:1:1", "tt1234567:1:2"]);
+    expect(library.programmes[0].showProgress.id).toBe("tt1234567:1:1");
+  });
+
+  it("accepts another valid starting episode and rejects specials, unreleased, and unknown episodes", async () => {
+    mockCinemeta();
+    const choices = ["tt1234567:0:1", "tt1234567:1:3", "tt1234567:9:9"];
+    for (const startingEpisodeId of choices) {
+      const created = await create(); const headers = await parentAccess(created);
+      const response = await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/library`, {
+        method: "POST", headers: { ...headers, "content-type": "application/json" },
+        body: JSON.stringify({ type: "show", imdbId: "tt1234567", startingEpisodeId }),
+      });
+      expect(response.status).toBe(400);
+    }
+
+    const created = await create(); const headers = await parentAccess(created);
+    const accepted = await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/library`, {
+      method: "POST", headers: { ...headers, "content-type": "application/json" },
+      body: JSON.stringify({ type: "show", imdbId: "tt1234567", startingEpisodeId: "tt1234567:1:2" }),
+    });
+    expect(await accepted.json<any>()).toMatchObject({ programme: { showProgress: { id: "tt1234567:1:2" } } });
+  });
+
+  it("approves a movie once and reports a duplicate without another Cinemeta request", async () => {
+    const created = await create(); const headers = await parentAccess(created); mockCinemeta();
+    const request = () => SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/library`, {
+      method: "POST", headers: { ...headers, "content-type": "application/json" }, body: JSON.stringify({ type: "movie", imdbId: "tt7654321" }),
+    });
+    expect((await request()).status).toBe(201);
+    const duplicate = await request();
+    expect(duplicate.status).toBe(409);
+    expect(await duplicate.json()).toMatchObject({ error: expect.stringContaining("already") });
+    const library = await (await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/library`, { headers })).json<any>();
+    expect(library.programmes).toHaveLength(1);
+    expect(library.programmes[0]).toMatchObject({ imdbId: "tt7654321", type: "movie" });
   });
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  test: { include: ["test/**/*.test.ts"] },
   plugins: [
     cloudflareTest({
       wrangler: { configPath: "./wrangler.test.jsonc" },

--- a/wrangler.browser.jsonc
+++ b/wrangler.browser.jsonc
@@ -1,0 +1,18 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "kids-channels-browser-test",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-07-24",
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "kids-channels-browser",
+      "database_id": "11111111-1111-1111-1111-111111111111",
+      "migrations_dir": "migrations"
+    }
+  ],
+  "vars": {
+    "CONFIG_SECRET": "browser-test-config-secret-at-least-32-characters",
+    "CINEMETA_ORIGIN": "http://127.0.0.1:8791"
+  }
+}


### PR DESCRIPTION
## Summary

- add authenticated Cinemeta search and metadata endpoints for shows and movies
- add the Approved Library D1 model while retaining canonical IMDb and episode identifiers
- filter shows to regular released episodes and initialise Show Progress at S01E01 or a Parent-selected valid episode
- add Parent Page search, metadata/artwork cards, approval controls, duplicate feedback, and library display
- cover the network boundary and complete Worker flow with integration tests, plus the Parent workflow with Playwright and a local Cinemeta stub

## Verification

- `pnpm typecheck`
- `pnpm test`
- `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium pnpm test:browser`
- `pnpm exec wrangler deploy --dry-run`
- `pnpm db:migrate:local`
- live Cinemeta search and series metadata contract spot-check

Closes #4
