### PR TITLE
Play one approved episode without a stream picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pnpm test:browser
 # Or run both suites with: pnpm test:all
 ```
 
-The integration and protocol suite runs the complete creation, PIN unlock, provider validation, Cinemeta search, approval, encrypted storage, manifest, and catalog flow inside the Cloudflare Worker runtime against an isolated test D1 database. Cinemeta and Torrentio are stubbed only at outbound `fetch`; deterministic tests contain no real credentials or signed media URLs. The Playwright suite starts a local Worker, local D1 database, and network-boundary Cinemeta stub to exercise the Parent Page in Chromium. Set `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` to use an existing Chromium binary instead of downloading one.
+The integration and protocol suite runs the complete creation, PIN unlock, provider validation, Cinemeta search, approval, encrypted storage, and catalog-to-current-episode stream flow inside the Cloudflare Worker runtime against an isolated test D1 database. Cinemeta and Torrentio are stubbed only at outbound `fetch`; deterministic tests contain no real credentials or signed media URLs. The Playwright suite starts a local Worker, local D1 database, and network-boundary Cinemeta stub to exercise the Parent Page in Chromium. Set `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` to use an existing Chromium binary instead of downloading one.
 
 A credential-safe real-provider check is documented separately in [`docs/torrentio-contract-probe.md`](docs/torrentio-contract-probe.md). It is optional and never runs in CI.
 
@@ -67,3 +67,5 @@ The Worker never places the Parent PIN or provider credentials in installation U
 - `GET /addons/:secret/manifest.json` — Household Stremio manifest
 - `GET /addons/:secret/catalog/tv/kids-tv-channel.json` — one TV Channel tile
 - `GET /addons/:secret/catalog/movie/kids-movie-channel.json` — one Movie Channel tile
+- `GET /addons/:secret/meta/tv/kids-channels:tv.json` — the TV Channel's Current Programme metadata
+- `GET /addons/:secret/stream/tv/:canonicalEpisodeId.json` — exactly one acceptable cached stream for the Current Programme

--- a/migrations/0004_add_current_programmes.sql
+++ b/migrations/0004_add_current_programmes.sql
@@ -1,0 +1,13 @@
+CREATE TABLE current_programmes (
+  household_id TEXT NOT NULL,
+  channel TEXT NOT NULL CHECK (channel IN ('tv', 'movie')),
+  programme_id TEXT NOT NULL,
+  video_id TEXT NOT NULL,
+  selected_at TEXT NOT NULL,
+  PRIMARY KEY (household_id, channel),
+  FOREIGN KEY (household_id) REFERENCES households(id) ON DELETE CASCADE,
+  FOREIGN KEY (programme_id) REFERENCES approved_programmes(id) ON DELETE CASCADE
+);
+
+CREATE INDEX current_programmes_video_idx
+  ON current_programmes (household_id, channel, video_id);

--- a/scripts/probe-torrentio.mjs
+++ b/scripts/probe-torrentio.mjs
@@ -19,7 +19,7 @@ if (!manifestValue) {
 
     const cached = body.streams.filter((stream) => {
       const label = `${stream?.name ?? ""}\n${stream?.title ?? ""}`;
-      return typeof stream?.url === "string" && /(?:^|\s|\n)RD\+(?:\s|$)/i.test(label) && !/download/i.test(label);
+      return typeof stream?.url === "string" && /(?:^|[^a-z0-9])RD\+(?=$|[^a-z0-9])/i.test(label) && !/download/i.test(label);
     });
     const acceptable = cached.filter((stream) => /\b1080p?\b/i.test(`${stream?.name ?? ""}\n${stream?.title ?? ""}`));
     console.log(`Probe succeeded: manifest valid; cached direct results=${cached.length}; acceptable 1080p results=${acceptable.length}.`);

--- a/src/current-programme.ts
+++ b/src/current-programme.ts
@@ -1,0 +1,75 @@
+import type { CinemetaEpisode } from "./cinemeta";
+
+export interface TvCurrentProgramme {
+  programmeId: string;
+  imdbId: string;
+  showTitle: string;
+  description?: string;
+  poster?: string;
+  background?: string;
+  episode: CinemetaEpisode;
+}
+
+interface CurrentProgrammeRow {
+  programme_id: string;
+  imdb_id: string;
+  show_title: string;
+  description: string | null;
+  poster: string | null;
+  background: string | null;
+  video_id: string;
+  season: number;
+  episode: number;
+  episode_title: string;
+  released_at: string;
+  overview: string | null;
+}
+
+function fromRow(row: CurrentProgrammeRow): TvCurrentProgramme {
+  return {
+    programmeId: row.programme_id,
+    imdbId: row.imdb_id,
+    showTitle: row.show_title,
+    description: row.description ?? undefined,
+    poster: row.poster ?? undefined,
+    background: row.background ?? undefined,
+    episode: {
+      id: row.video_id,
+      season: row.season,
+      episode: row.episode,
+      title: row.episode_title,
+      released: row.released_at,
+      overview: row.overview ?? undefined,
+    },
+  };
+}
+
+async function selectedTvProgramme(db: D1Database, householdId: string): Promise<TvCurrentProgramme | null> {
+  const row = await db.prepare(`SELECT current.programme_id, programme.imdb_id, programme.title AS show_title,
+      programme.description, programme.poster, programme.background, episode.video_id, episode.season,
+      episode.episode, episode.title AS episode_title, episode.released_at, episode.overview
+    FROM current_programmes current
+    JOIN approved_programmes programme ON programme.id = current.programme_id
+    JOIN show_episodes episode ON episode.programme_id = current.programme_id AND episode.video_id = current.video_id
+    WHERE current.household_id = ? AND current.channel = 'tv'`)
+    .bind(householdId).first<CurrentProgrammeRow>();
+  return row ? fromRow(row) : null;
+}
+
+export async function tvCurrentProgramme(db: D1Database, householdId: string): Promise<TvCurrentProgramme | null> {
+  const existing = await selectedTvProgramme(db, householdId);
+  if (existing) return existing;
+
+  await db.prepare(`INSERT OR IGNORE INTO current_programmes
+      (household_id, channel, programme_id, video_id, selected_at)
+    SELECT programme.household_id, 'tv', programme.id, progress.next_video_id, ?
+    FROM approved_programmes programme
+    JOIN show_progress progress ON progress.programme_id = programme.id
+    JOIN show_episodes episode ON episode.programme_id = programme.id AND episode.video_id = progress.next_video_id
+    WHERE programme.household_id = ? AND programme.content_type = 'show'
+    ORDER BY programme.approved_at, programme.id
+    LIMIT 1`)
+    .bind(new Date().toISOString(), householdId).run();
+
+  return selectedTvProgramme(db, householdId);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
 import { approveProgramme, approvedLibrary, hasApprovedProgramme } from "./approved-library";
 import { CinemetaClient, type ContentType } from "./cinemeta";
+import { tvCurrentProgramme } from "./current-programme";
 import { createHousehold, findHousehold, validPin, verifyPin } from "./households";
-import { providerConfiguration, saveProviderConfiguration } from "./provider-config";
+import { decryptedManifestUrl, providerConfiguration, saveProviderConfiguration } from "./provider-config";
 import { issueParentToken, verifyParentToken } from "./secrets";
 import { parseTorrentioManifestUrl, TorrentioProvider } from "./stream-provider";
-import { catalogFor, manifestFor } from "./stremio";
+import { catalogFor, manifestFor, TV_CHANNEL_ID, tvChannelMetadata } from "./stremio";
 
 export interface Env {
   DB: D1Database;
@@ -247,6 +248,10 @@ async function authorizedParent(request: Request, householdId: string, deploymen
   return verifyParentToken(authorization.slice(7), householdId, deploymentSecret);
 }
 
+function decodedPathSegment(value: string): string | null {
+  try { return decodeURIComponent(value); } catch { return null; }
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
@@ -385,6 +390,33 @@ export default {
       if (!(await findHousehold(env.DB, catalogMatch[1]))) return json({ error: "Household not found." }, 404);
       const catalog = catalogFor(catalogMatch[2], catalogMatch[3], url.origin);
       return catalog ? json(catalog) : json({ metas: [] });
+    }
+
+    const metaMatch = path.match(/^\/addons\/([A-Za-z0-9_-]+)\/meta\/tv\/([^/]+)\.json$/);
+    if (request.method === "GET" && metaMatch) {
+      const household = await findHousehold(env.DB, metaMatch[1]);
+      if (!household) return json({ error: "Household not found." }, 404);
+      if (decodedPathSegment(metaMatch[2]) !== TV_CHANNEL_ID) return json({ meta: null });
+      return json(tvChannelMetadata(await tvCurrentProgramme(env.DB, household.id)));
+    }
+
+    const streamMatch = path.match(/^\/addons\/([A-Za-z0-9_-]+)\/stream\/tv\/([^/]+)\.json$/);
+    if (request.method === "GET" && streamMatch) {
+      const household = await findHousehold(env.DB, streamMatch[1]);
+      if (!household) return json({ error: "Household not found." }, 404);
+      const current = await tvCurrentProgramme(env.DB, household.id);
+      const episodeId = decodedPathSegment(streamMatch[2]);
+      if (!current || current.episode.id !== episodeId || !env.CONFIG_SECRET) return json({ streams: [] });
+
+      try {
+        const manifestUrl = await decryptedManifestUrl(env.DB, household.id, env.CONFIG_SECRET);
+        if (!manifestUrl) return json({ streams: [] });
+        const provider = new TorrentioProvider(new URL(manifestUrl));
+        const selected = provider.firstAcceptable(await provider.streams("series", current.episode.id));
+        return json({ streams: selected ? [selected] : [] });
+      } catch {
+        return json({ streams: [] });
+      }
     }
 
     return json({ error: "Not found." }, 404);

--- a/src/stream-provider.ts
+++ b/src/stream-provider.ts
@@ -37,7 +37,7 @@ function direct(stream: ProviderStream): boolean {
 
 function cached(stream: ProviderStream): boolean {
   const label = `${stream.name ?? ""}\n${stream.title ?? ""}`;
-  return direct(stream) && /(?:^|\s|\n)RD\+(?:\s|$)/i.test(label) && !/download/i.test(label);
+  return direct(stream) && /(?:^|[^a-z0-9])RD\+(?=$|[^a-z0-9])/i.test(label) && !/download/i.test(label);
 }
 
 function suitable(stream: ProviderStream): boolean {

--- a/src/stremio.ts
+++ b/src/stremio.ts
@@ -1,5 +1,8 @@
+import type { TvCurrentProgramme } from "./current-programme";
+
 export const TV_CATALOG_ID = "kids-tv-channel";
 export const MOVIE_CATALOG_ID = "kids-movie-channel";
+export const TV_CHANNEL_ID = "kids-channels:tv";
 
 export interface HouseholdIdentity {
   id: string;
@@ -12,7 +15,7 @@ export function manifestFor(household: HouseholdIdentity) {
     version: "0.1.0",
     name: "Kids Channels",
     description: "Two parent-curated Channels for the household.",
-    resources: ["catalog"],
+    resources: ["catalog", "meta", "stream"],
     types: ["tv", "movie"],
     catalogs: [
       { type: "tv", id: TV_CATALOG_ID, name: "Kids Channels - TV" },
@@ -25,12 +28,36 @@ export function manifestFor(household: HouseholdIdentity) {
   };
 }
 
+export function tvChannelMetadata(current: TvCurrentProgramme | null) {
+  if (!current) return { meta: null };
+  return {
+    meta: {
+      id: TV_CHANNEL_ID,
+      type: "tv",
+      name: "TV Channel",
+      description: current.description ?? `Current Programme: ${current.showTitle}`,
+      poster: current.poster,
+      background: current.background,
+      videos: [
+        {
+          id: current.episode.id,
+          title: `${current.showTitle} — ${current.episode.title}`,
+          released: current.episode.released,
+          season: current.episode.season,
+          episode: current.episode.episode,
+          overview: current.episode.overview,
+        },
+      ],
+    },
+  };
+}
+
 export function catalogFor(type: string, id: string, origin: string) {
   if (type === "tv" && id === TV_CATALOG_ID) {
     return {
       metas: [
         {
-          id: "kids-channels:tv",
+          id: TV_CHANNEL_ID,
           type: "tv",
           name: "TV Channel",
           description: "Your household's approved shows, in episode order.",

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -36,7 +36,12 @@ beforeEach(async () => {
   await env.DB.prepare(`CREATE TABLE IF NOT EXISTS show_progress (
     programme_id TEXT PRIMARY KEY NOT NULL, next_video_id TEXT NOT NULL
   )`).run();
+  await env.DB.prepare(`CREATE TABLE IF NOT EXISTS current_programmes (
+    household_id TEXT NOT NULL, channel TEXT NOT NULL, programme_id TEXT NOT NULL,
+    video_id TEXT NOT NULL, selected_at TEXT NOT NULL, PRIMARY KEY (household_id, channel)
+  )`).run();
   await env.DB.prepare("CREATE INDEX IF NOT EXISTS households_secret_idx ON households (secret)").run();
+  await env.DB.prepare("DELETE FROM current_programmes").run();
   await env.DB.prepare("DELETE FROM show_progress").run();
   await env.DB.prepare("DELETE FROM show_episodes").run();
   await env.DB.prepare("DELETE FROM approved_programmes").run();
@@ -352,6 +357,102 @@ describe("Cinemeta Approved Library", () => {
   });
 });
 
+describe("TV Channel Current Programme playback", () => {
+  const providerPath = "/providers=family/realdebrid=TEST-CREDENTIAL";
+  const manifestUrl = `https://torrentio.example${providerPath}/manifest.json`;
+  const canonicalEpisodeId = "tt2468101:1:1";
+  const selectedStream = { name: "Torrentio\nRD+", title: "First acceptable 1080p", url: "https://media.example/selected?token=SIGNED" };
+  const alternativeStream = { name: "Torrentio\nRD+", title: "Alternative 1080p", url: "https://media.example/alternative?token=OTHER" };
+  const showMeta = {
+    id: "tt2468101", imdb_id: "tt2468101", type: "series", name: "Playback Show",
+    description: "The approved family show.", poster: "https://images.example/playback.jpg",
+    videos: [
+      { id: canonicalEpisodeId, season: 1, episode: 1, title: "Beginning", released: "2020-01-01T00:00:00.000Z" },
+      { id: "tt2468101:1:2", season: 1, episode: 2, title: "Later", released: "2020-01-08T00:00:00.000Z" },
+    ],
+  };
+
+  async function arrangePlayback(playbackFailure = false) {
+    const providerRequests: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const path = decodeURIComponent(new URL(input instanceof Request ? input.url : input.toString()).pathname);
+      if (path === `${providerPath}/manifest.json`) return Response.json({ id: "org.example.torrentio", resources: ["stream"] });
+      if (path === `${providerPath}/stream/movie/tt0111161.json`) return Response.json({ streams: [selectedStream] });
+      if (path === "/meta/series/tt2468101.json") return Response.json({ meta: showMeta });
+      if (path === `${providerPath}/stream/series/${canonicalEpisodeId}.json`) {
+        providerRequests.push(path);
+        return playbackFailure
+          ? Response.json({}, { status: 503 })
+          : Response.json({ streams: [
+            { name: "Torrentio\nRD+", title: "Unsuitable 2160p", url: "https://media.example/unsuitable" },
+            selectedStream,
+            alternativeStream,
+          ] });
+      }
+      throw new Error(`unexpected outbound request: ${path}`);
+    });
+
+    const created = await create();
+    const secret = secretFrom(created);
+    const unlocked = await SELF.fetch(`https://kids.test/api/households/${secret}/unlock`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ pin: "123456" }),
+    });
+    const { parentToken } = await unlocked.json<{ parentToken: string }>();
+    const authorization = `Bearer ${parentToken}`;
+    const configured = await SELF.fetch(`https://kids.test/api/households/${secret}/provider`, {
+      method: "PUT", headers: { "content-type": "application/json", authorization }, body: JSON.stringify({ manifestUrl }),
+    });
+    expect(configured.status).toBe(200);
+    const approved = await SELF.fetch(`https://kids.test/api/households/${secret}/library`, {
+      method: "POST", headers: { "content-type": "application/json", authorization },
+      body: JSON.stringify({ type: "show", imdbId: "tt2468101" }),
+    });
+    expect(approved.status).toBe(201);
+    return { created, secret, providerRequests };
+  }
+
+  it("drives the catalog-to-stream path with canonical identity and exactly the first acceptable stream", async () => {
+    const { created, providerRequests } = await arrangePlayback();
+    const base = created.manifestUrl.replace(/\/manifest\.json$/, "");
+
+    const catalog = await (await SELF.fetch(`${base}/catalog/tv/kids-tv-channel.json`)).json<any>();
+    expect(catalog.metas).toHaveLength(1);
+    const metadata = await (await SELF.fetch(`${base}/meta/tv/${encodeURIComponent(catalog.metas[0].id)}.json`)).json<any>();
+    expect(metadata.meta).toMatchObject({ id: "kids-channels:tv", type: "tv", videos: [{
+      id: canonicalEpisodeId, season: 1, episode: 1, title: "Playback Show — Beginning",
+    }] });
+    expect(metadata.meta.videos).toHaveLength(1);
+
+    const before = await env.DB.prepare("SELECT next_video_id FROM show_progress").first<{ next_video_id: string }>();
+    const response = await SELF.fetch(`${base}/stream/tv/${encodeURIComponent(metadata.meta.videos[0].id)}.json`);
+    const text = await response.text();
+    expect(response.status).toBe(200);
+    expect(JSON.parse(text).streams).toEqual([selectedStream]);
+    expect(text).not.toContain(alternativeStream.url);
+    expect(providerRequests).toEqual([`${providerPath}/stream/series/${canonicalEpisodeId}.json`]);
+
+    const after = await env.DB.prepare("SELECT next_video_id FROM show_progress").first<{ next_video_id: string }>();
+    const current = await env.DB.prepare("SELECT video_id FROM current_programmes WHERE channel = 'tv'").first<{ video_id: string }>();
+    expect(before?.next_video_id).toBe(canonicalEpisodeId);
+    expect(after).toEqual(before);
+    expect(current?.video_id).toBe(canonicalEpisodeId);
+  });
+
+  it("returns a protocol-safe empty result and preserves Current Programme when Torrentio fails", async () => {
+    const { created } = await arrangePlayback(true);
+    const base = created.manifestUrl.replace(/\/manifest\.json$/, "");
+    const metadata = await (await SELF.fetch(`${base}/meta/tv/${encodeURIComponent("kids-channels:tv")}.json`)).json<any>();
+    const currentBefore = await env.DB.prepare("SELECT * FROM current_programmes WHERE channel = 'tv'").first<Record<string, unknown>>();
+    const progressBefore = await env.DB.prepare("SELECT * FROM show_progress").first<Record<string, unknown>>();
+
+    const response = await SELF.fetch(`${base}/stream/tv/${encodeURIComponent(metadata.meta.videos[0].id)}.json`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ streams: [] });
+    expect(await env.DB.prepare("SELECT * FROM current_programmes WHERE channel = 'tv'").first()).toEqual(currentBefore);
+    expect(await env.DB.prepare("SELECT * FROM show_progress").first()).toEqual(progressBefore);
+  });
+});
+
 describe("Stremio protocol", () => {
   it("serves a configurable household-specific manifest", async () => {
     const created = await create();
@@ -362,7 +463,7 @@ describe("Stremio protocol", () => {
     expect(manifest).toMatchObject({
       version: "0.1.0",
       name: "Kids Channels",
-      resources: ["catalog"],
+      resources: ["catalog", "meta", "stream"],
       types: ["tv", "movie"],
       behaviorHints: { configurable: true, configurationRequired: false },
     });

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -252,6 +252,15 @@ describe("Torrentio configuration", () => {
       { name: "Torrentio\nRD+", title: "Unsuitable 2160p", url: "https://media.example/4k" }, first, second,
     ])).toBe(first);
   });
+
+  it("recognizes Torrentio's bracketed cached Real-Debrid marker", () => {
+    const cached = {
+      name: "Torrentio RD",
+      title: "[RD+] Example.Release.1080p.WEB-DL",
+      url: "https://media.example/cached",
+    };
+    expect(firstAcceptableCachedStream([cached])).toBe(cached);
+  });
 });
 
 describe("Cinemeta Approved Library", () => {


### PR DESCRIPTION
## Summary

- persist the TV Channel's first Current Programme from an approved show's Show Progress
- expose Current Programme metadata with the canonical Cinemeta episode ID
- resolve that canonical episode through the Household's encrypted Torrentio configuration and return only its first acceptable cached stream
- preserve Current Programme and Show Progress on playback requests and provider failures
- cover the complete catalog → metadata → stream Worker path, including protocol-safe provider failure

## Testing

- `pnpm test`
- `pnpm typecheck`
- `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium pnpm test:browser`

Closes #5
