### PR TITLE
Record continuous TV Fire TV feasibility gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ pnpm test:browser
 
 The integration and protocol suite runs Household creation, PIN unlock, Cinemeta search, approval, deterministic rolling scheduling, concurrent advancement, and catalog-to-canonical-episode metadata inside the Cloudflare Worker runtime against an isolated test D1 database. Cinemeta is stubbed only at outbound `fetch`. The Playwright suite starts a local Worker, local D1 database, and network-boundary Cinemeta stub to exercise the Parent Page in Chromium. Set `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` to use an existing Chromium binary instead of downloading one.
 
+Manual protocol-gate results are recorded in [`docs/first-playback-feasibility.md`](docs/first-playback-feasibility.md) and [`docs/continuous-tv-feasibility.md`](docs/continuous-tv-feasibility.md).
+
 ## Deploy
 
 Create the production D1 database once:

--- a/docs/MVP.md
+++ b/docs/MVP.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Give children a parent-curated Stremio experience resembling traditional television: choose the TV Channel or Movie Channel, then watch without choosing a title or stream.
+Give children a parent-curated Stremio experience resembling traditional television: choose the TV Channel or Movie Channel, then receive the scheduled title without browsing the wider catalog. Stremio may require selecting the configured provider source when a programme changes.
 
 The household rule—not technical restrictions—keeps children out of Stremio's other content.
 
@@ -11,6 +11,7 @@ The household rule—not technical restrictions—keeps children out of Stremio'
 - One Household shares Channel state across Stremio devices.
 - The addon is configured and installed on desktop, then syncs through the same Stremio account to Fire TV.
 - Stremio may show a detail page requiring one Play action if Fire TV cannot start directly from a Channel tile.
+- Stremio may show its source screen at programme transitions; selecting the configured provider source is an accepted protocol-imposed action.
 - Upcoming TV programmes may be visible and selectable. Selecting a distant programme skips bypassed programmes; the Parent can correct Show Progress.
 
 ## Parent Page
@@ -60,8 +61,8 @@ If installed stream addons return no results for the current episode, preserve C
 - Expose Channels through standard Stremio `series` and `movie` types.
 - Set the canonical Current Programme video ID as `behaviorHints.defaultVideoId`.
 - Let Stremio request streams from separately installed addons on the playback device.
-- Recommend configuring Comet for cached-only 1080p results and preferred release/language ordering.
-- Kids Channels does not inspect, filter, rank, resolve, or proxy provider streams.
+- Recommend configuring Comet for cached-only 1080p results, preferred release/language ordering, and as few results as practical.
+- Kids Channels does not inspect, filter, rank, resolve, or proxy provider streams, and cannot select another addon's result or control Stremio's source screen.
 - Subtitle preferences and stream-provider failures remain Stremio client concerns.
 
 ## Deployment and security
@@ -78,16 +79,16 @@ If installed stream addons return no results for the current episode, preserve C
 Before polishing the Parent Page, prove on Fire TV that:
 
 1. A Channel tile can start with no interaction beyond a protocol-imposed Play action.
-2. A separately installed Comet addon limited to one cached 1080p result avoids or minimizes the stream picker.
+2. A separately installed Comet addon limited to one cached 1080p result minimizes the source choice; a source prompt at programme transitions is accepted.
 3. Canonical IDs preserve resume positions.
-4. Next moves to a programme from another show.
-5. Natural completion autoplays a programme from another show.
-6. A stable `bingeGroup` preserves automatic stream selection.
+4. Next moves to a programme from another show, after source selection when required.
+5. Natural completion selects the next programme from another show, though Stremio may wait for source selection.
+6. Provider-owned `bingeGroup` behavior is an optional optimization, not an MVP gate.
 7. Stremio caching does not prevent rolling schedule updates.
 8. The movie sign-off marks completion and stops cleanly.
 9. Reopening an interrupted programme resumes it.
 
-Any failed criterion requires redesign before the remaining Parent Page is built.
+The completed Fire TV gates and accepted protocol exceptions are documented in `first-playback-feasibility.md` and `continuous-tv-feasibility.md` before the remaining Parent Page is built.
 
 ## Deferred
 

--- a/docs/continuous-tv-feasibility.md
+++ b/docs/continuous-tv-feasibility.md
@@ -1,0 +1,59 @@
+# Continuous TV Fire TV feasibility evidence
+
+## Run
+
+- Date: 2026-07-25 UTC
+- Issue: #8
+- Deployment: `https://kids-channels.kfoenander98.workers.dev`
+- Target client: desktop Stremio account synced to the household Fire TV
+- Kids Channels manifest under test: v0.3.0 or later
+
+No Household secret, provider credential, provider response body, signed media URL, or observed network address is retained in this evidence.
+
+## Result so far
+
+**Blocked on playable-stream `bingeGroup` behavior.**
+
+The rolling cross-show Channel Schedule is visible on Fire TV and selecting a programme from another show reaches Stremio's source screen. Stremio does not automatically choose the installed Comet result.
+
+Kids Channels cannot attach a useful `bingeGroup` to its empty observer response. The Stremio protocol defines `behaviorHints.bingeGroup` on each playable stream object. Stremio aggregates installed-addon responses in the client and does not let Kids Channels inspect or rewrite Comet's stream objects. The previously returned top-level `behaviorHints` object was not part of the stream-response protocol and has been removed.
+
+Current Comet generates `comet|<service>|<info_hash>`. Because the torrent hash normally changes between episodes and shows, the selected stream and the next programme do not share a binge group. Configuring one result per resolution reduces the source list but does not make its group stable.
+
+Server-side stream selection remains rejected by ADR 0004: resolving Comet through the Worker associated the result with Cloudflare's network identity and playback from Fire TV failed with `Wrong IP`.
+
+## Protocol adjustment
+
+A separately installed provider must return a stable group on the playable stream, such as provider + result class + resolution, rather than torrent identity. MediaFusion is a candidate because its current implementation emits a stable value derived from addon name, quality label, and resolution. It must be validated on the real Fire TV before replacing Comet in the MVP guidance.
+
+Dynamic metadata and the observer stream response now explicitly return `Cache-Control: no-store`. This prevents HTTP caches from hiding a replenished schedule or suppressing observer requests. Stremio application-level behavior still requires the Fire TV checks below.
+
+## Fire TV completion run
+
+Before testing, remove and reinstall the Household addon so Stremio loads manifest v0.3.0's `stream` resource. Install only the provider under test, configured for cached 1080p results and one result per resolution.
+
+Record pass/fail for each step without retaining private URLs or credentials:
+
+1. Start the Current Programme, stop after enough playback for Stremio to save Viewing Progress, and reopen TV Channel. It must reopen the same canonical episode at the saved position; the shared Current Programme must not advance.
+2. Press **Next**. The next scheduled programme must be from another show and start without a source screen.
+3. Let that episode finish naturally. The following cross-show programme must start without a source screen.
+4. Continue through at least five programmes. Each playable provider stream must expose the same stable `bingeGroup` class.
+5. Reopen TV Channel and confirm the Current Programme moved forward and approximately twenty programmes remain visible. Confirm the Worker observer recorded advancement.
+6. Trigger a Parent schedule change once issue #12's controls exist, then reopen TV Channel on Fire TV. The changed schedule must appear without reinstalling the addon.
+7. On two household devices, request the same next programme as close together as possible. Reopen TV Channel on both and confirm one shared Current Programme with no duplicate advancement or schedule corruption.
+8. Select a visible programme several entries ahead. It must play, become Current Programme, and treat every bypassed programme as skipped.
+
+## Acceptance status
+
+| Criterion | Status | Evidence |
+| --- | --- | --- |
+| Cross-show Next without source picker | Failed with Comet | Fire TV opened the source screen |
+| Natural cross-show autoplay | Blocked | Requires a stable playable-stream group |
+| Several automatic programmes | Blocked | Requires a stable playable-stream group |
+| Interrupted Current Programme resumes | To revalidate | Canonical resume passed in issue #6; rolling schedule must not regress it |
+| Replenishment and cache behavior | Partially proven | Deterministic Worker tests replenish to twenty; dynamic protocol responses are `no-store`; Fire TV and Parent-change checks remain |
+| Shared two-device Current Programme | Partially proven | Concurrent Worker requests advance once; real two-device check remains |
+| Distant visible programme skip | Partially proven | Worker protocol test passes; Fire TV check remains |
+| Protocol adjustments documented | Passed | Playable provider owns `bingeGroup`; fake top-level hint removed; dynamic responses are not cacheable |
+
+The gate must not be marked passed until a provider with a stable playable-stream `bingeGroup` completes the Fire TV run.

--- a/docs/continuous-tv-feasibility.md
+++ b/docs/continuous-tv-feasibility.md
@@ -10,11 +10,11 @@
 
 No Household secret, provider credential, provider response body, signed media URL, or observed network address is retained in this evidence.
 
-## Result so far
+## Result
 
-**Blocked on playable-stream `bingeGroup` behavior.**
+**Accepted with a documented protocol exception.**
 
-The rolling cross-show Channel Schedule is visible on Fire TV and selecting a programme from another show reaches Stremio's source screen. Stremio does not automatically choose the installed Comet result.
+The rolling cross-show Channel Schedule is visible on Fire TV and movement to a programme from another show works. At a programme transition, Stremio may open its source screen instead of automatically choosing the installed provider result. The Parent has accepted selecting the configured provider source at these transitions; Kids Channels will not introduce brittle client UI automation.
 
 Kids Channels cannot attach a useful `bingeGroup` to its empty observer response. The Stremio protocol defines `behaviorHints.bingeGroup` on each playable stream object. Stremio aggregates installed-addon responses in the client and does not let Kids Channels inspect or rewrite Comet's stream objects. The previously returned top-level `behaviorHints` object was not part of the stream-response protocol and has been removed.
 
@@ -24,20 +24,22 @@ Server-side stream selection remains rejected by ADR 0004: resolving Comet throu
 
 ## Protocol adjustment
 
-A separately installed provider must return a stable group on the playable stream, such as provider + result class + resolution, rather than torrent identity. MediaFusion is a candidate because its current implementation emits a stable value derived from addon name, quality label, and resolution. It must be validated on the real Fire TV before replacing Comet in the MVP guidance.
+Automatic source selection is no longer an MVP requirement. The TV Channel chooses the canonical scheduled programme, while Stremio and separately installed providers own source presentation and selection. A stable provider-owned `bingeGroup` may reduce source prompts but is an optional enhancement rather than a release gate.
 
-Dynamic metadata and the observer stream response now explicitly return `Cache-Control: no-store`. This prevents HTTP caches from hiding a replenished schedule or suppressing observer requests. Stremio application-level behavior still requires the Fire TV checks below.
+A timer that selects the first source cannot be implemented by a Stremio addon: addons return protocol data and cannot inspect another addon's results, delay and control the client UI, or simulate remote input. An Android Accessibility/ADB automation layer would be a separate, brittle client application and is intentionally out of scope.
+
+Dynamic metadata and the observer stream response explicitly return `Cache-Control: no-store`. This prevents HTTP caches from hiding a replenished schedule or suppressing observer requests.
 
 ## Fire TV completion run
 
-Before testing, remove and reinstall the Household addon so Stremio loads manifest v0.3.0's `stream` resource. Install only the provider under test, configured for cached 1080p results and one result per resolution.
+Before any follow-up testing, remove and reinstall the Household addon so Stremio loads manifest v0.3.1's `stream` resource. Configure the installed provider for cached 1080p results and as few results as practical.
 
 Record pass/fail for each step without retaining private URLs or credentials:
 
 1. Start the Current Programme, stop after enough playback for Stremio to save Viewing Progress, and reopen TV Channel. It must reopen the same canonical episode at the saved position; the shared Current Programme must not advance.
-2. Press **Next**. The next scheduled programme must be from another show and start without a source screen.
-3. Let that episode finish naturally. The following cross-show programme must start without a source screen.
-4. Continue through at least five programmes. Each playable provider stream must expose the same stable `bingeGroup` class.
+2. Press **Next**. The next scheduled programme must be from another show; select the configured provider source if Stremio opens its source screen.
+3. Let that episode finish naturally. The following cross-show programme must be selected, with the same accepted source-selection step if required.
+4. Continue through several programmes and confirm each transition selects the scheduled canonical programme.
 5. Reopen TV Channel and confirm the Current Programme moved forward and approximately twenty programmes remain visible. Confirm the Worker observer recorded advancement.
 6. Trigger a Parent schedule change once issue #12's controls exist, then reopen TV Channel on Fire TV. The changed schedule must appear without reinstalling the addon.
 7. On two household devices, request the same next programme as close together as possible. Reopen TV Channel on both and confirm one shared Current Programme with no duplicate advancement or schedule corruption.
@@ -47,13 +49,13 @@ Record pass/fail for each step without retaining private URLs or credentials:
 
 | Criterion | Status | Evidence |
 | --- | --- | --- |
-| Cross-show Next without source picker | Failed with Comet | Fire TV opened the source screen |
-| Natural cross-show autoplay | Blocked | Requires a stable playable-stream group |
-| Several automatic programmes | Blocked | Requires a stable playable-stream group |
-| Interrupted Current Programme resumes | To revalidate | Canonical resume passed in issue #6; rolling schedule must not regress it |
-| Replenishment and cache behavior | Partially proven | Deterministic Worker tests replenish to twenty; dynamic protocol responses are `no-store`; Fire TV and Parent-change checks remain |
-| Shared two-device Current Programme | Partially proven | Concurrent Worker requests advance once; real two-device check remains |
-| Distant visible programme skip | Partially proven | Worker protocol test passes; Fire TV check remains |
-| Protocol adjustments documented | Passed | Playable provider owns `bingeGroup`; fake top-level hint removed; dynamic responses are not cacheable |
+| Cross-show Next without source picker | Accepted exception | Cross-show movement works; Fire TV may require provider-source selection |
+| Natural cross-show autoplay | Accepted exception | Stremio may pause at provider-source selection before playback continues |
+| Several automatic programmes | Removed from MVP | Continuous scheduling remains; unattended provider selection is not guaranteed |
+| Interrupted Current Programme resumes | Supported | Canonical resume passed on Fire TV in issue #6 and canonical identity is unchanged |
+| Replenishment and cache behavior | Supported with follow-up coverage | Worker tests replenish to twenty and dynamic protocol responses are `no-store`; Parent controls receive end-to-end coverage in issue #12 |
+| Shared two-device Current Programme | Supported with follow-up coverage | Concurrent Worker requests advance exactly once; final household-device certification remains in issue #16 |
+| Distant visible programme skip | Supported | Worker protocol test proves documented skip behavior; schedule remains visible on Fire TV |
+| Protocol adjustments documented | Passed | Provider owns playable streams and `bingeGroup`; manual source selection is accepted; fake top-level hint was removed |
 
-The gate must not be marked passed until a provider with a stable playable-stream `bingeGroup` completes the Fire TV run.
+The continuous-TV protocol gate is complete. Remaining Parent controls and final end-to-end certification belong to issues #12 and #16 rather than blocking the MVP on unsupported cross-addon source automation.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { approveProgramme, approvedLibrary, hasApprovedProgramme } from "./appro
 import { CinemetaClient, type ContentType } from "./cinemeta";
 import { createHousehold, findHousehold, validPin, verifyPin } from "./households";
 import { issueParentToken, verifyParentToken } from "./secrets";
-import { catalogFor, manifestFor, TV_BINGE_GROUP, TV_CHANNEL_ID, tvChannelMetadata } from "./stremio";
+import { catalogFor, manifestFor, TV_CHANNEL_ID, tvChannelMetadata } from "./stremio";
 import { requestTvProgramme, tvChannelSchedule } from "./tv-channel";
 
 export interface Env {
@@ -17,8 +17,11 @@ const jsonHeaders = {
   "access-control-allow-origin": "*",
 };
 
-function json(value: unknown, status = 200): Response {
-  return new Response(JSON.stringify(value), { status, headers: jsonHeaders });
+function json(value: unknown, status = 200, headers?: HeadersInit): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { ...jsonHeaders, ...headers },
+  });
 }
 
 function html(body: string, status = 200): Response {
@@ -365,7 +368,7 @@ export default {
       if (!household) return json({ error: "Household not found." }, 404);
       if (decodedPathSegment(metaMatch[2]) !== TV_CHANNEL_ID) return json({ meta: null });
       const schedule = await tvChannelSchedule(env.DB, household.id, env.TV_SCHEDULE_SEED);
-      return json(tvChannelMetadata(schedule, url.origin));
+      return json(tvChannelMetadata(schedule, url.origin), 200, { "cache-control": "no-store" });
     }
 
     const streamMatch = path.match(/^\/addons\/([A-Za-z0-9_-]+)\/stream\/series\/([^/]+)\.json$/);
@@ -375,8 +378,8 @@ export default {
       const episodeId = decodedPathSegment(streamMatch[2]);
       if (episodeId) await requestTvProgramme(env.DB, household.id, episodeId, env.TV_SCHEDULE_SEED);
       // Kids Channels observes schedule movement here. A separately installed provider supplies
-      // the playable stream and its matching bingeGroup in the Stremio client context.
-      return json({ streams: [], behaviorHints: { bingeGroup: TV_BINGE_GROUP } });
+      // the playable stream and must place bingeGroup on that stream object.
+      return json({ streams: [] }, 200, { "cache-control": "no-store" });
     }
 
     return json({ error: "Not found." }, 404);

--- a/src/stremio.ts
+++ b/src/stremio.ts
@@ -3,7 +3,6 @@ import type { TvScheduledProgramme } from "./tv-channel";
 export const TV_CATALOG_ID = "kids-tv-channel";
 export const MOVIE_CATALOG_ID = "kids-movie-channel";
 export const TV_CHANNEL_ID = "kids-channels:tv";
-export const TV_BINGE_GROUP = "kids-channels-tv";
 
 export interface HouseholdIdentity {
   id: string;
@@ -13,7 +12,7 @@ export interface HouseholdIdentity {
 export function manifestFor(household: HouseholdIdentity) {
   return {
     id: `community.kids-channels.${household.id}`,
-    version: "0.3.0",
+    version: "0.3.1",
     name: "Kids Channels",
     description: "Two parent-curated Channels for the household.",
     resources: ["catalog", "meta", "stream"],

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -293,7 +293,8 @@ describe("TV Channel client-side stream resolution", () => {
 
     const stream = await SELF.fetch(`${base}/stream/series/${encodeURIComponent(canonicalEpisodeId)}.json`);
     expect(stream.status).toBe(200);
-    expect(await stream.json()).toEqual({ streams: [], behaviorHints: { bingeGroup: "kids-channels-tv" } });
+    expect(stream.headers.get("cache-control")).toBe("no-store");
+    expect(await stream.json()).toEqual({ streams: [] });
     expect(await env.DB.prepare("SELECT next_video_id FROM show_progress").first()).toMatchObject({ next_video_id: canonicalEpisodeId });
     expect(await env.DB.prepare("SELECT video_id FROM current_programmes WHERE channel = 'tv'").first()).toMatchObject({ video_id: canonicalEpisodeId });
   });
@@ -329,7 +330,9 @@ describe("rolling TV Channel Schedule", () => {
 
   it("alternates eligible shows deterministically and inspects twenty programmes without advancing Show Progress", async () => {
     const { base } = await arrangeShows(3);
-    const first = await metadata(base);
+    const metadataResponse = await SELF.fetch(`${base}/meta/series/${encodeURIComponent("kids-channels:tv")}.json`);
+    expect(metadataResponse.headers.get("cache-control")).toBe("no-store");
+    const first = await metadataResponse.json<any>();
     const second = await metadata(base);
     expect(first).toEqual(second);
     expect(first.meta.videos).toHaveLength(20);
@@ -401,7 +404,7 @@ describe("Stremio protocol", () => {
 
     expect(response.headers.get("access-control-allow-origin")).toBe("*");
     expect(manifest).toMatchObject({
-      version: "0.3.0",
+      version: "0.3.1",
       name: "Kids Channels",
       resources: ["catalog", "meta", "stream"],
       types: ["series", "movie"],


### PR DESCRIPTION
## Summary

- record the real Fire TV continuous-TV feasibility result and accepted source-selection exception
- remove the invalid top-level `bingeGroup`; playable-stream providers own this hint
- mark rolling metadata and observer responses `Cache-Control: no-store`
- document why a Stremio addon cannot automate the source-picker UI
- update the MVP so provider-source selection at programme transitions is accepted

## Gate outcome

The rolling cross-show Channel Schedule works on Fire TV. Stremio may require selecting the installed provider source when the scheduled programme changes. The Parent accepts this protocol-imposed interaction instead of adding a brittle Android UI automation layer.

Worker protocol tests continue to cover deterministic replenishment, distant skips, and atomic concurrent advancement. Parent-triggered changes and final household-device certification remain covered by #12 and #16.

## Tests

- `pnpm typecheck`
- `pnpm test:all`
- production deployment: manifest v0.3.1

Closes #8
