### PR TITLE
Apply Approved Library changes to active Channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pnpm db:migrate:local
 pnpm dev
 ```
 
-Keep `.dev.vars` private; `CONFIG_SECRET` signs one-hour Parent sessions. Open `http://localhost:8787`, choose a six-digit Parent PIN, and create a Household. The page returns the opaque manifest URL and a `stremio://` installation action. Open the Parent Page, unlock it, then search Cinemeta to approve shows and movies. Shows default to S01E01; choose another regular released episode before approval when needed.
+Keep `.dev.vars` private; `CONFIG_SECRET` signs one-hour Parent sessions. Open `http://localhost:8787`, choose a six-digit Parent PIN, and create a Household. The page returns the opaque manifest URL and a `stremio://` installation action. Open the Parent Page, unlock it, then search Cinemeta to approve shows and movies. Shows default to S01E01; choose another regular released episode before approval when needed. Approved shows can be paused without losing Show Progress, programmes can be removed from future Channel selections, and upcoming TV selections can be regenerated without changing the Current Programme.
 
 Local D1 data is stored by Wrangler under `.wrangler/`. There is no forgotten-PIN recovery.
 
@@ -64,6 +64,8 @@ The Worker never receives stream-provider or Real-Debrid credentials. Household 
 - `GET /api/households/:secret/cinemeta/search?q=…` — search Cinemeta shows and movies (Parent bearer token required)
 - `GET /api/households/:secret/cinemeta/title/:type/:imdbId` — retrieve canonical title and released episode metadata (Parent bearer token required)
 - `GET|POST /api/households/:secret/library` — view or add to the Approved Library (Parent bearer token required)
+- `PATCH|DELETE /api/households/:secret/library/:programmeId` — pause/resume a show or remove a programme and reconcile its active Channel (Parent bearer token required)
+- `POST /api/households/:secret/tv-schedule/regenerate` — regenerate future TV selections without advancing Show Progress (Parent bearer token required)
 - `GET /addons/:secret/manifest.json` — Household Stremio manifest
 - `GET /addons/:secret/catalog/series/kids-tv-channel.json` — one TV Channel tile
 - `GET /addons/:secret/catalog/movie/kids-movie-channel.json` — one Movie Channel tile

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ pnpm dev
 
 Keep `.dev.vars` private; `CONFIG_SECRET` signs one-hour Parent sessions. Open `http://localhost:8787`, choose a six-digit Parent PIN, and create a Household. The page returns the opaque manifest URL and a `stremio://` installation action. Open the Parent Page, unlock it, then search Cinemeta to approve shows and movies. Shows default to S01E01; choose another regular released episode before approval when needed. Approved shows can be paused without losing Show Progress, programmes can be removed from future Channel selections, and upcoming TV selections can be regenerated without changing the Current Programme.
 
+Stremio retains loaded addon metadata in memory even when responses use `Cache-Control: no-store`. After a Parent changes the Approved Library or regenerates selections, fully close and reopen Stremio to load the updated Channel. The Worker state changes immediately and does not interrupt media already playing.
+
 Local D1 data is stored by Wrangler under `.wrangler/`. There is no forgotten-PIN recovery.
 
 ## Test

--- a/docs/adr/0005-restart-stremio-after-parent-changes.md
+++ b/docs/adr/0005-restart-stremio-after-parent-changes.md
@@ -1,0 +1,7 @@
+# Restart Stremio after Parent changes
+
+Stremio retains an already-loaded addon metadata request in its in-memory resource model even when the Worker returns `Cache-Control: no-store`. Returning to the Channel or navigating elsewhere does not reliably force the identical metadata request to load again; fully closing and reopening Stremio does.
+
+Approved Library changes and TV selection regeneration therefore update Worker and D1 Channel state immediately, while the Parent must restart Stremio before the client displays that state. Media already playing remains uninterrupted. After restart, removed or paused content is absent from the refreshed Channel and cannot be relaunched from its schedule.
+
+This is an accepted MVP protocol limitation. Kids Channels cannot push cache invalidation into Stremio, and owning provider stream resolution to enforce server-side playback was rejected by ADR 0004 after IP-sensitive provider results failed with `Wrong IP`. The Parent Page must clearly instruct the Parent to restart Stremio after these changes.

--- a/docs/continuous-tv-feasibility.md
+++ b/docs/continuous-tv-feasibility.md
@@ -28,7 +28,7 @@ Automatic source selection is no longer an MVP requirement. The TV Channel choos
 
 A timer that selects the first source cannot be implemented by a Stremio addon: addons return protocol data and cannot inspect another addon's results, delay and control the client UI, or simulate remote input. An Android Accessibility/ADB automation layer would be a separate, brittle client application and is intentionally out of scope.
 
-Dynamic metadata and the observer stream response explicitly return `Cache-Control: no-store`. This prevents HTTP caches from hiding a replenished schedule or suppressing observer requests.
+Dynamic metadata and the observer stream response explicitly return `Cache-Control: no-store`. This prevents HTTP intermediary caches from hiding a replenished schedule or suppressing observer requests, but it does not invalidate metadata already retained in Stremio's in-memory resource model. A July 2026 Parent-change validation confirmed that Stremio reuses the identical loaded metadata request until the client fully closes and reopens. The Parent has accepted this protocol limitation for the MVP; the Parent Page must instruct them to restart Stremio after Approved Library or regeneration changes.
 
 ## Fire TV completion run
 
@@ -41,7 +41,7 @@ Record pass/fail for each step without retaining private URLs or credentials:
 3. Let that episode finish naturally. The following cross-show programme must be selected, with the same accepted source-selection step if required.
 4. Continue through several programmes and confirm each transition selects the scheduled canonical programme.
 5. Reopen TV Channel and confirm the Current Programme moved forward and approximately twenty programmes remain visible. Confirm the Worker observer recorded advancement.
-6. Trigger a Parent schedule change once issue #12's controls exist, then reopen TV Channel on Fire TV. The changed schedule must appear without reinstalling the addon.
+6. Trigger a Parent schedule change once issue #12's controls exist, fully close and reopen Stremio, then reopen TV Channel on Fire TV. The changed schedule must appear without reinstalling the addon.
 7. On two household devices, request the same next programme as close together as possible. Reopen TV Channel on both and confirm one shared Current Programme with no duplicate advancement or schedule corruption.
 8. Select a visible programme several entries ahead. It must play, become Current Programme, and treat every bypassed programme as skipped.
 
@@ -53,7 +53,7 @@ Record pass/fail for each step without retaining private URLs or credentials:
 | Natural cross-show autoplay | Accepted exception | Stremio may pause at provider-source selection before playback continues |
 | Several automatic programmes | Removed from MVP | Continuous scheduling remains; unattended provider selection is not guaranteed |
 | Interrupted Current Programme resumes | Supported | Canonical resume passed on Fire TV in issue #6 and canonical identity is unchanged |
-| Replenishment and cache behavior | Supported with follow-up coverage | Worker tests replenish to twenty and dynamic protocol responses are `no-store`; Parent controls receive end-to-end coverage in issue #12 |
+| Replenishment and cache behavior | Accepted exception | Worker tests replenish to twenty and dynamic responses are `no-store`, but Stremio retains loaded metadata in memory; a full client restart is required after Parent changes |
 | Shared two-device Current Programme | Supported with follow-up coverage | Concurrent Worker requests advance exactly once; final household-device certification remains in issue #16 |
 | Distant visible programme skip | Supported | Worker protocol test proves documented skip behavior; schedule remains visible on Fire TV |
 | Protocol adjustments documented | Passed | Provider owns playable streams and `bingeGroup`; manual source selection is accepted; fake top-level hint was removed |

--- a/migrations/0009_add_programme_pause_state.sql
+++ b/migrations/0009_add_programme_pause_state.sql
@@ -1,0 +1,1 @@
+ALTER TABLE approved_programmes ADD COLUMN paused_at TEXT;

--- a/src/approved-library.ts
+++ b/src/approved-library.ts
@@ -12,6 +12,7 @@ export interface ApprovedProgramme {
   genres: string[];
   imdbRating?: string;
   approvedAt: string;
+  pausedAt?: string;
   episodes?: CinemetaEpisode[];
   showProgress?: CinemetaEpisode;
 }
@@ -28,6 +29,7 @@ interface StoredProgramme {
   genres_json: string;
   imdb_rating: string | null;
   approved_at: string;
+  paused_at: string | null;
   next_video_id: string | null;
 }
 
@@ -55,6 +57,7 @@ function programmeFromRow(row: StoredProgramme): ApprovedProgramme {
     genres: JSON.parse(row.genres_json) as string[],
     imdbRating: row.imdb_rating ?? undefined,
     approvedAt: row.approved_at,
+    pausedAt: row.paused_at ?? undefined,
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,7 @@ function parentPage(secret: string): string {
       </form>
       <div id="search-results"></div>
       <h2>Approved Library</h2>
+      <p class="notice">Stremio keeps Channel details in memory. After changing the Approved Library or regenerating selections, fully close and reopen Stremio to load the updated Channel.</p>
       <button id="regenerate-tv" type="button" class="secondary">Regenerate upcoming TV selections</button>
       <p id="library-status" role="status"></p>
       <div id="library"><p>No programmes approved yet.</p></div>
@@ -396,7 +397,7 @@ export default {
         await env.DB.prepare("UPDATE approved_programmes SET paused_at = ? WHERE id = ? AND household_id = ?")
           .bind(pausedAt, programme.id, household.id).run();
         await refreshTvChannelSchedule(env.DB, household.id, false, env.TV_SCHEDULE_SEED);
-        return json({ message: input.paused ? "Show paused without changing Show Progress." : "Show resumed." });
+        return json({ message: `${input.paused ? "Show paused without changing Show Progress." : "Show resumed."} Restart Stremio to refresh the Channel.` });
       }
 
       if (programme.content_type === "show") {
@@ -416,7 +417,7 @@ export default {
         ]);
         await reconcileMovieChannel(env.DB, household.id, env.MOVIE_ROTATION_SEED);
       }
-      return json({ message: `${programme.content_type === "show" ? "Show" : "Movie"} removed from future Channel selections.` });
+      return json({ message: `${programme.content_type === "show" ? "Show" : "Movie"} removed from future Channel selections. Restart Stremio to refresh the Channel.` });
     }
 
     const regenerateMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/tv-schedule\/regenerate$/);
@@ -426,7 +427,7 @@ export default {
         return json({ error: "Parent authentication is required." }, 401);
       }
       await refreshTvChannelSchedule(env.DB, household.id, true, env.TV_SCHEDULE_SEED);
-      return json({ message: "Upcoming TV selections regenerated without changing the Current Programme or Show Progress." });
+      return json({ message: "Upcoming TV selections regenerated without changing the Current Programme or Show Progress. Restart Stremio to refresh the Channel." });
     }
 
     const parentMatch = path.match(/^\/households\/([A-Za-z0-9_-]+)$/);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 import { approveProgramme, approvedLibrary, hasApprovedProgramme } from "./approved-library";
 import { CinemetaClient, type ContentType } from "./cinemeta";
 import { createHousehold, findHousehold, validPin, verifyPin } from "./households";
-import { movieChannelProgramme, MOVIE_CHANNEL_ID, parseSignOffId, requestMovieSignOff } from "./movie-channel";
+import { movieChannelProgramme, MOVIE_CHANNEL_ID, parseSignOffId, reconcileMovieChannel, requestMovieSignOff } from "./movie-channel";
 import { issueParentToken, verifyParentToken } from "./secrets";
 import { movieSignOff } from "./sign-off-media";
 import { catalogFor, manifestFor, movieChannelMetadata, TV_CHANNEL_ID, tvChannelMetadata } from "./stremio";
-import { requestTvProgramme, tvChannelSchedule } from "./tv-channel";
+import { refreshTvChannelSchedule, requestTvProgramme, tvChannelSchedule } from "./tv-channel";
 
 export interface Env {
   DB: D1Database;
@@ -141,6 +141,8 @@ function parentPage(secret: string): string {
       </form>
       <div id="search-results"></div>
       <h2>Approved Library</h2>
+      <button id="regenerate-tv" type="button" class="secondary">Regenerate upcoming TV selections</button>
+      <p id="library-status" role="status"></p>
       <div id="library"><p>No programmes approved yet.</p></div>
       <p class="notice">Install and configure a stream addon such as Comet in Stremio. Kids Channels selects the programme; Stremio resolves streams on your device.</p>
     </section>
@@ -161,6 +163,17 @@ function parentPage(secret: string): string {
           const progress = document.createElement('p'); progress.textContent = 'Starts at S' + String(programme.showProgress.season).padStart(2, '0') + 'E' + String(programme.showProgress.episode).padStart(2, '0') + ' — ' + programme.showProgress.title;
           details.append(progress);
         }
+        if (approved) {
+          if (programme.type === 'show') {
+            const pause = document.createElement('button'); pause.type = 'button';
+            pause.textContent = programme.pausedAt ? 'Resume show' : 'Pause show';
+            pause.addEventListener('click', () => changeProgramme(programme.id, {paused: !programme.pausedAt}, pause));
+            details.append(pause);
+          }
+          const remove = document.createElement('button'); remove.type = 'button'; remove.className = 'secondary';
+          remove.textContent = 'Remove ' + (programme.type === 'show' ? 'show' : 'movie');
+          remove.addEventListener('click', () => removeProgramme(programme.id, remove)); details.append(remove);
+        }
         card.append(image, details); return {card, details};
       }
       async function loadLibrary() {
@@ -168,6 +181,22 @@ function parentPage(secret: string): string {
         const result = await response.json(); const output = document.querySelector('#library'); output.replaceChildren();
         if (!result.programmes.length) { const empty = document.createElement('p'); empty.textContent = 'No programmes approved yet.'; output.append(empty); return; }
         result.programmes.forEach(programme => output.append(programmeCard(programme, true).card));
+      }
+      async function changeProgramme(programmeId, body, button) {
+        button.disabled = true;
+        const response = await fetch('/api/households/${secret}/library/' + encodeURIComponent(programmeId), {
+          method: 'PATCH', headers: {...headers(), 'content-type': 'application/json'}, body: JSON.stringify(body)
+        });
+        const result = await response.json();
+        if (!response.ok) { button.disabled = false; document.querySelector('#library-status').textContent = result.error; return; }
+        document.querySelector('#library-status').textContent = result.message; await loadLibrary();
+      }
+      async function removeProgramme(programmeId, button) {
+        button.disabled = true;
+        const response = await fetch('/api/households/${secret}/library/' + encodeURIComponent(programmeId), {method: 'DELETE', headers: headers()});
+        const result = await response.json();
+        if (!response.ok) { button.disabled = false; document.querySelector('#library-status').textContent = result.error; return; }
+        document.querySelector('#library-status').textContent = result.message; await loadLibrary();
       }
       async function approve(programme, startingEpisodeId, button) {
         button.disabled = true;
@@ -205,6 +234,12 @@ function parentPage(secret: string): string {
         parentToken = result.parentToken; document.querySelector('#install').href = result.installUrl;
         document.querySelector('#manifest').textContent = result.manifestUrl;
         form.hidden = true; document.querySelector('#result').hidden = false; await loadLibrary();
+      });
+      document.querySelector('#regenerate-tv').addEventListener('click', async (event) => {
+        const button = event.currentTarget; button.disabled = true;
+        const response = await fetch('/api/households/${secret}/tv-schedule/regenerate', {method: 'POST', headers: headers()});
+        const result = await response.json(); button.disabled = false;
+        document.querySelector('#library-status').textContent = response.ok ? result.message : result.error;
       });
       document.querySelector('#search-form').addEventListener('submit', async (event) => {
         event.preventDefault(); const status = document.querySelector('#search-status'); status.textContent = 'Searching Cinemeta…';
@@ -338,6 +373,60 @@ export default {
         if (message.includes("UNIQUE")) return json({ error: "This programme is already in the Approved Library." }, 409);
         return json({ error: "Cinemeta metadata is temporarily unavailable." }, 502);
       }
+    }
+
+    const libraryProgrammeMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/library\/([A-Za-z0-9-]+)$/);
+    if (libraryProgrammeMatch && (request.method === "PATCH" || request.method === "DELETE")) {
+      const household = await findHousehold(env.DB, libraryProgrammeMatch[1]);
+      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household.id, env.CONFIG_SECRET))) {
+        return json({ error: "Parent authentication is required." }, 401);
+      }
+      const programme = await env.DB.prepare(`SELECT id, content_type FROM approved_programmes
+        WHERE id = ? AND household_id = ?`).bind(libraryProgrammeMatch[2], household.id)
+        .first<{ id: string; content_type: ContentType }>();
+      if (!programme) return json({ error: "Programme was not found in the Approved Library." }, 404);
+
+      if (request.method === "PATCH") {
+        let input: { paused?: unknown } = {};
+        try { input = await request.json() as typeof input; } catch { /* handled below */ }
+        if (programme.content_type !== "show" || typeof input.paused !== "boolean") {
+          return json({ error: "Choose whether to pause or resume an approved show." }, 400);
+        }
+        const pausedAt = input.paused ? new Date().toISOString() : null;
+        await env.DB.prepare("UPDATE approved_programmes SET paused_at = ? WHERE id = ? AND household_id = ?")
+          .bind(pausedAt, programme.id, household.id).run();
+        await refreshTvChannelSchedule(env.DB, household.id, false, env.TV_SCHEDULE_SEED);
+        return json({ message: input.paused ? "Show paused without changing Show Progress." : "Show resumed." });
+      }
+
+      if (programme.content_type === "show") {
+        await env.DB.batch([
+          env.DB.prepare("DELETE FROM channel_schedule WHERE household_id = ? AND programme_id = ?").bind(household.id, programme.id),
+          env.DB.prepare("DELETE FROM current_programmes WHERE household_id = ? AND programme_id = ?").bind(household.id, programme.id),
+          env.DB.prepare("DELETE FROM show_progress WHERE programme_id = ?").bind(programme.id),
+          env.DB.prepare("DELETE FROM show_episodes WHERE programme_id = ?").bind(programme.id),
+          env.DB.prepare("DELETE FROM approved_programmes WHERE id = ? AND household_id = ?").bind(programme.id, household.id),
+        ]);
+        await refreshTvChannelSchedule(env.DB, household.id, false, env.TV_SCHEDULE_SEED);
+      } else {
+        await env.DB.batch([
+          env.DB.prepare("DELETE FROM movie_rotation WHERE household_id = ? AND programme_id = ?").bind(household.id, programme.id),
+          env.DB.prepare("DELETE FROM current_programmes WHERE household_id = ? AND programme_id = ?").bind(household.id, programme.id),
+          env.DB.prepare("DELETE FROM approved_programmes WHERE id = ? AND household_id = ?").bind(programme.id, household.id),
+        ]);
+        await reconcileMovieChannel(env.DB, household.id, env.MOVIE_ROTATION_SEED);
+      }
+      return json({ message: `${programme.content_type === "show" ? "Show" : "Movie"} removed from future Channel selections.` });
+    }
+
+    const regenerateMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/tv-schedule\/regenerate$/);
+    if (request.method === "POST" && regenerateMatch) {
+      const household = await findHousehold(env.DB, regenerateMatch[1]);
+      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household.id, env.CONFIG_SECRET))) {
+        return json({ error: "Parent authentication is required." }, 401);
+      }
+      await refreshTvChannelSchedule(env.DB, household.id, true, env.TV_SCHEDULE_SEED);
+      return json({ message: "Upcoming TV selections regenerated without changing the Current Programme or Show Progress." });
     }
 
     const parentMatch = path.match(/^\/households\/([A-Za-z0-9_-]+)$/);

--- a/src/movie-channel.ts
+++ b/src/movie-channel.ts
@@ -137,14 +137,80 @@ async function current(db: D1Database, householdId: string): Promise<MovieProgra
   return row ? programmeFromRow(row) : null;
 }
 
-export async function movieChannelProgramme(
+export async function reconcileMovieChannel(
   db: D1Database,
   householdId: string,
   configuredSeed?: string,
 ): Promise<MovieProgramme | null> {
   await initialize(db, householdId, configuredSeed);
   await synchronizeRotation(db, householdId);
+  const state = await db.prepare(`SELECT cycle, current_position, selection_seed
+    FROM movie_channel_state WHERE household_id = ?`).bind(householdId).first<MovieStateRow>();
+  if (!state) return null;
+
+  const movies = await approvedMovies(db, householdId);
+  if (movies.length === 0) {
+    await db.batch([
+      db.prepare("DELETE FROM current_programmes WHERE household_id = ? AND channel = 'movie'").bind(householdId),
+      db.prepare("DELETE FROM movie_advancements WHERE household_id = ?").bind(householdId),
+      db.prepare("DELETE FROM movie_rotation WHERE household_id = ?").bind(householdId),
+      db.prepare("DELETE FROM movie_channel_state WHERE household_id = ?").bind(householdId),
+    ]);
+    return null;
+  }
+
+  const existing = await current(db, householdId);
+  if (existing) return existing;
+
+  const next = await db.prepare(`SELECT rotation.position, rotation.programme_id
+    FROM movie_rotation rotation
+    JOIN approved_programmes programme ON programme.id = rotation.programme_id
+    WHERE rotation.household_id = ? AND rotation.cycle = ? AND rotation.position > ?
+      AND rotation.consumed_at IS NULL AND programme.content_type = 'movie'
+    ORDER BY rotation.position LIMIT 1`).bind(householdId, state.cycle, state.current_position)
+    .first<{ position: number; programme_id: string }>();
+  const now = new Date().toISOString();
+  if (next) {
+    const nextMovie = movies.find((movie) => movie.programme_id === next.programme_id);
+    if (!nextMovie) return null;
+    await db.batch([
+      db.prepare("UPDATE movie_channel_state SET current_position = ? WHERE household_id = ?")
+        .bind(next.position, householdId),
+      db.prepare(`INSERT INTO current_programmes (household_id, channel, programme_id, video_id, selected_at)
+        VALUES (?, 'movie', ?, ?, ?)
+        ON CONFLICT(household_id, channel) DO UPDATE SET programme_id = excluded.programme_id,
+          video_id = excluded.video_id, selected_at = excluded.selected_at`)
+        .bind(householdId, nextMovie.programme_id, nextMovie.imdb_id, now),
+    ]);
+    return current(db, householdId);
+  }
+
+  const nextCycle = state.cycle + 1;
+  const rotation = shuffled(movies, state.selection_seed, nextCycle);
+  const statements: D1PreparedStatement[] = [
+    db.prepare("UPDATE movie_channel_state SET cycle = ?, current_position = 0 WHERE household_id = ?")
+      .bind(nextCycle, householdId),
+  ];
+  for (const [position, movie] of rotation.entries()) {
+    statements.push(db.prepare(`INSERT OR IGNORE INTO movie_rotation
+      (household_id, cycle, position, programme_id) VALUES (?, ?, ?, ?)`)
+      .bind(householdId, nextCycle, position, movie.programme_id));
+  }
+  statements.push(db.prepare(`INSERT INTO current_programmes
+    (household_id, channel, programme_id, video_id, selected_at) VALUES (?, 'movie', ?, ?, ?)
+    ON CONFLICT(household_id, channel) DO UPDATE SET programme_id = excluded.programme_id,
+      video_id = excluded.video_id, selected_at = excluded.selected_at`)
+    .bind(householdId, rotation[0].programme_id, rotation[0].imdb_id, now));
+  await db.batch(statements);
   return current(db, householdId);
+}
+
+export async function movieChannelProgramme(
+  db: D1Database,
+  householdId: string,
+  configuredSeed?: string,
+): Promise<MovieProgramme | null> {
+  return reconcileMovieChannel(db, householdId, configuredSeed);
 }
 
 export function parseSignOffId(videoId: string): { cycle: number; position: number } | null {

--- a/src/tv-channel.ts
+++ b/src/tv-channel.ts
@@ -91,7 +91,7 @@ async function loadShows(db: D1Database, householdId: string): Promise<Show[]> {
       progress.next_video_id
     FROM approved_programmes programme
     JOIN show_progress progress ON progress.programme_id = programme.id
-    WHERE programme.household_id = ? AND programme.content_type = 'show'
+    WHERE programme.household_id = ? AND programme.content_type = 'show' AND programme.paused_at IS NULL
     ORDER BY programme.approved_at, programme.id`).bind(householdId).all<ShowRow>();
 
   const episodeRows = await db.prepare(`SELECT episode.programme_id, episode.video_id, episode.season,
@@ -313,6 +313,78 @@ async function advanceOnce(
       .bind(householdId, programme.position, programme.programmeId, programme.episode.id, now, ...ownership));
   }
   await db.batch(statements);
+}
+
+export async function refreshTvChannelSchedule(
+  db: D1Database,
+  householdId: string,
+  regenerate = false,
+  configuredSeed?: string,
+): Promise<TvScheduledProgramme[]> {
+  const currentState = await state(db, householdId);
+  if (!currentState) {
+    await initializeSchedule(db, householdId, configuredSeed);
+    return scheduleRows(db, householdId);
+  }
+
+  const shows = await loadShows(db, householdId);
+  if (shows.length === 0) {
+    await db.batch([
+      db.prepare("DELETE FROM channel_schedule WHERE household_id = ? AND channel = 'tv'").bind(householdId),
+      db.prepare("DELETE FROM current_programmes WHERE household_id = ? AND channel = 'tv'").bind(householdId),
+      db.prepare("DELETE FROM channel_advancements WHERE household_id = ? AND channel = 'tv'").bind(householdId),
+      db.prepare("DELETE FROM channel_state WHERE household_id = ? AND channel = 'tv'").bind(householdId),
+    ]);
+    return [];
+  }
+
+  const storedCurrent = await db.prepare(`SELECT programme_id, video_id FROM current_programmes
+    WHERE household_id = ? AND channel = 'tv'`).bind(householdId)
+    .first<{ programme_id: string; video_id: string }>();
+  const currentShow = storedCurrent
+    ? shows.find((show) => show.programmeId === storedCurrent.programme_id
+      && show.episodes.some((episode) => episode.id === storedCurrent.video_id))
+    : undefined;
+  const currentEpisode = currentShow?.episodes.find((episode) => episode.id === storedCurrent?.video_id);
+  const seed = regenerate ? crypto.randomUUID() : currentState.selection_seed;
+  const position = currentState.current_position;
+  const programmes: TvScheduledProgramme[] = currentShow && currentEpisode
+    ? [{
+      position,
+      programmeId: currentShow.programmeId,
+      imdbId: currentShow.imdbId,
+      showTitle: currentShow.title,
+      description: currentShow.description,
+      poster: currentShow.poster,
+      background: currentShow.background,
+      episode: currentEpisode,
+    }, ...project(shows, seed, position + 1, TV_SCHEDULE_LENGTH - 1, [{
+      programmeId: currentShow.programmeId,
+      videoId: currentEpisode.id,
+    }])]
+    : project(shows, seed, position, TV_SCHEDULE_LENGTH);
+
+  if (programmes.length === 0) return [];
+  const now = new Date().toISOString();
+  const first = programmes[0];
+  const statements: D1PreparedStatement[] = [
+    db.prepare("DELETE FROM channel_schedule WHERE household_id = ? AND channel = 'tv'").bind(householdId),
+    db.prepare(`UPDATE channel_state SET selection_seed = ?
+      WHERE household_id = ? AND channel = 'tv'`).bind(seed, householdId),
+    db.prepare(`INSERT INTO current_programmes (household_id, channel, programme_id, video_id, selected_at)
+      VALUES (?, 'tv', ?, ?, ?)
+      ON CONFLICT(household_id, channel) DO UPDATE SET programme_id = excluded.programme_id,
+        video_id = excluded.video_id, selected_at = excluded.selected_at`)
+      .bind(householdId, first.programmeId, first.episode.id, now),
+  ];
+  for (const programme of programmes) {
+    statements.push(db.prepare(`INSERT INTO channel_schedule
+      (household_id, channel, position, programme_id, video_id, scheduled_at)
+      VALUES (?, 'tv', ?, ?, ?, ?)`)
+      .bind(householdId, programme.position, programme.programmeId, programme.episode.id, now));
+  }
+  await db.batch(statements);
+  return scheduleRows(db, householdId);
 }
 
 export async function requestTvProgramme(

--- a/test/browser/approved-library.spec.ts
+++ b/test/browser/approved-library.spec.ts
@@ -15,6 +15,7 @@ async function unlockHousehold(page: import("@playwright/test").Page) {
   await page.getByLabel("Parent PIN").fill("123456");
   await page.getByRole("button", { name: "Unlock Household" }).click();
   await expect(page.getByRole("heading", { name: "Approved Library" })).toBeVisible();
+  await expect(page.getByText("fully close and reopen Stremio")).toBeVisible();
 }
 
 test("a Parent searches Cinemeta and approves a movie and a show from another starting episode", async ({ page }) => {
@@ -74,6 +75,7 @@ test("a Parent searches Cinemeta and approves a movie and a show from another st
 
   await page.getByRole("button", { name: "Regenerate upcoming TV selections" }).click();
   await expect(page.locator("#library-status")).toContainText("without changing the Current Programme or Show Progress");
+  await expect(page.locator("#library-status")).toContainText("Restart Stremio");
   expect((await channelMetadata()).tv.meta?.behaviorHints.defaultVideoId).toBe("tt1234567:1:2");
 
   await page.locator("#library .programme").filter({ hasText: "The Example" })

--- a/test/browser/approved-library.spec.ts
+++ b/test/browser/approved-library.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "@playwright/test";
 
+interface ChannelMetadata {
+  meta: null | { behaviorHints: { defaultVideoId: string } };
+}
+
 async function unlockHousehold(page: import("@playwright/test").Page) {
   await page.goto("/");
   await page.getByLabel("Choose a six-digit Parent PIN").fill("123456");
@@ -44,4 +48,41 @@ test("a Parent searches Cinemeta and approves a movie and a show from another st
 
   const approvedShow = page.locator("#library .programme").filter({ hasText: "The Example" });
   await expect(approvedShow).toContainText("Starts at S01E02 — Second");
+
+  const manifestUrl = await page.locator("#manifest").textContent();
+  expect(manifestUrl).toBeTruthy();
+  const addonBase = manifestUrl!.replace(/\/manifest\.json$/, "");
+  const channelMetadata = () => page.evaluate(async (base) => {
+    const [tv, movie] = await Promise.all([
+      fetch(base + "/meta/series/" + encodeURIComponent("kids-channels:tv") + ".json").then(async (response) => await response.json() as ChannelMetadata),
+      fetch(base + "/meta/movie/" + encodeURIComponent("kids-channels:movie") + ".json").then(async (response) => await response.json() as ChannelMetadata),
+    ]);
+    return { tv, movie };
+  }, addonBase);
+
+  const active = await channelMetadata();
+  expect(active.tv.meta?.behaviorHints.defaultVideoId).toBe("tt1234567:1:2");
+  expect(active.movie.meta?.behaviorHints.defaultVideoId).toBe("tt7654321");
+
+  await approvedShow.getByRole("button", { name: "Pause show" }).click();
+  await expect(page.locator("#library-status")).toContainText("Show paused");
+  expect((await channelMetadata()).tv.meta).toBeNull();
+  const pausedShow = page.locator("#library .programme").filter({ hasText: "The Example" });
+  await pausedShow.getByRole("button", { name: "Resume show" }).click();
+  await expect(page.locator("#library-status")).toContainText("Show resumed");
+  expect((await channelMetadata()).tv.meta?.behaviorHints.defaultVideoId).toBe("tt1234567:1:2");
+
+  await page.getByRole("button", { name: "Regenerate upcoming TV selections" }).click();
+  await expect(page.locator("#library-status")).toContainText("without changing the Current Programme or Show Progress");
+  expect((await channelMetadata()).tv.meta?.behaviorHints.defaultVideoId).toBe("tt1234567:1:2");
+
+  await page.locator("#library .programme").filter({ hasText: "The Example" })
+    .getByRole("button", { name: "Remove show" }).click();
+  await expect(page.locator("#library-status")).toContainText("Show removed");
+  expect((await channelMetadata()).tv.meta).toBeNull();
+
+  await page.locator("#library .programme").filter({ hasText: "Example: The Movie" })
+    .getByRole("button", { name: "Remove movie" }).click();
+  await expect(page.locator("#library-status")).toContainText("Movie removed");
+  expect((await channelMetadata()).movie.meta).toBeNull();
 });

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -20,7 +20,7 @@ beforeEach(async () => {
     id TEXT PRIMARY KEY NOT NULL, household_id TEXT NOT NULL, imdb_id TEXT NOT NULL,
     content_type TEXT NOT NULL, title TEXT NOT NULL, description TEXT, poster TEXT, background TEXT,
     release_info TEXT, genres_json TEXT NOT NULL DEFAULT '[]', imdb_rating TEXT, approved_at TEXT NOT NULL,
-    UNIQUE (household_id, content_type, imdb_id)
+    paused_at TEXT, UNIQUE (household_id, content_type, imdb_id)
   )`).run();
   await env.DB.prepare(`CREATE TABLE IF NOT EXISTS show_episodes (
     programme_id TEXT NOT NULL, video_id TEXT NOT NULL, season INTEGER NOT NULL, episode INTEGER NOT NULL,
@@ -410,6 +410,129 @@ describe("rolling TV Channel Schedule", () => {
       expect(await env.DB.prepare("SELECT next_video_id FROM show_progress WHERE programme_id = ?")
         .bind(`programme-${show}`).first()).toMatchObject({ next_video_id: `tt900000${show}:1:${expected}` });
     }
+  });
+});
+
+describe("Approved Library changes while Channels are active", () => {
+  async function arrangeActiveChannels() {
+    const created = await create();
+    const now = new Date().toISOString();
+    const statements: D1PreparedStatement[] = [];
+    for (let show = 1; show <= 2; show += 1) {
+      statements.push(env.DB.prepare(`INSERT INTO approved_programmes
+        (id, household_id, imdb_id, content_type, title, genres_json, approved_at)
+        VALUES (?, ?, ?, 'show', ?, '[]', ?)`)
+        .bind(`active-show-${show}`, created.householdId, `tt700000${show}`, `Active Show ${show}`, `${now}-${show}`));
+      for (let episode = 1; episode <= 25; episode += 1) {
+        statements.push(env.DB.prepare(`INSERT INTO show_episodes
+          (programme_id, video_id, season, episode, title, released_at) VALUES (?, ?, 1, ?, ?, ?)`)
+          .bind(`active-show-${show}`, `tt700000${show}:1:${episode}`, episode, `Episode ${episode}`, now));
+      }
+      statements.push(env.DB.prepare("INSERT INTO show_progress (programme_id, next_video_id) VALUES (?, ?)")
+        .bind(`active-show-${show}`, `tt700000${show}:1:1`));
+    }
+    for (let movie = 1; movie <= 3; movie += 1) {
+      statements.push(env.DB.prepare(`INSERT INTO approved_programmes
+        (id, household_id, imdb_id, content_type, title, genres_json, approved_at)
+        VALUES (?, ?, ?, 'movie', ?, '[]', ?)`)
+        .bind(`active-movie-${movie}`, created.householdId, `tt600000${movie}`, `Active Movie ${movie}`, `${now}-${movie}`));
+    }
+    await env.DB.batch(statements);
+
+    const secret = secretFrom(created);
+    const unlocked = await SELF.fetch(`https://kids.test/api/households/${secret}/unlock`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ pin: "123456" }),
+    });
+    const { parentToken } = await unlocked.json<{ parentToken: string }>();
+    const headers = { authorization: `Bearer ${parentToken}` };
+    const base = created.manifestUrl.replace(/\/manifest\.json$/, "");
+    const tvUrl = `${base}/meta/series/${encodeURIComponent("kids-channels:tv")}.json`;
+    const movieUrl = `${base}/meta/movie/${encodeURIComponent("kids-channels:movie")}.json`;
+    expect((await (await SELF.fetch(tvUrl)).json<any>()).meta).not.toBeNull();
+    expect((await (await SELF.fetch(movieUrl)).json<any>()).meta).not.toBeNull();
+    return { created, secret, headers, base, tvUrl, movieUrl };
+  }
+
+  it("pauses, resumes, regenerates, and removes shows without falsely advancing Show Progress", async () => {
+    const { created, secret, headers, base, tvUrl } = await arrangeActiveChannels();
+    const initial = await (await SELF.fetch(tvUrl)).json<any>();
+    const initialVideoId = initial.meta.behaviorHints.defaultVideoId as string;
+    const current = await env.DB.prepare("SELECT programme_id FROM current_programmes WHERE household_id = ? AND channel = 'tv'")
+      .bind(created.householdId).first<{ programme_id: string }>();
+    expect(current).toBeTruthy();
+    const progressBefore = await env.DB.prepare("SELECT programme_id, next_video_id FROM show_progress ORDER BY programme_id")
+      .all<{ programme_id: string; next_video_id: string }>();
+
+    const pause = await SELF.fetch(`https://kids.test/api/households/${secret}/library/${current!.programme_id}`, {
+      method: "PATCH", headers: { ...headers, "content-type": "application/json" }, body: JSON.stringify({ paused: true }),
+    });
+    expect(pause.status).toBe(200);
+    const whilePaused = await (await SELF.fetch(tvUrl)).json<any>();
+    expect(whilePaused.meta.behaviorHints.defaultVideoId).not.toBe(initialVideoId);
+    expect(whilePaused.meta.videos.every((video: any) => !video.id.startsWith(initialVideoId.split(":")[0]))).toBe(true);
+    expect(await env.DB.prepare("SELECT paused_at FROM approved_programmes WHERE id = ?").bind(current!.programme_id).first<string>("paused_at"))
+      .toBeTruthy();
+
+    const resume = await SELF.fetch(`https://kids.test/api/households/${secret}/library/${current!.programme_id}`, {
+      method: "PATCH", headers: { ...headers, "content-type": "application/json" }, body: JSON.stringify({ paused: false }),
+    });
+    expect(resume.status).toBe(200);
+    expect(await env.DB.prepare("SELECT paused_at FROM approved_programmes WHERE id = ?").bind(current!.programme_id).first<string>("paused_at"))
+      .toBeNull();
+    expect((await env.DB.prepare("SELECT programme_id, next_video_id FROM show_progress ORDER BY programme_id")
+      .all()).results).toEqual(progressBefore.results);
+
+    const beforeRegenerate = await (await SELF.fetch(tvUrl)).json<any>();
+    const seedBefore = await env.DB.prepare("SELECT selection_seed FROM channel_state WHERE household_id = ? AND channel = 'tv'")
+      .bind(created.householdId).first<string>("selection_seed");
+    const regenerate = await SELF.fetch(`https://kids.test/api/households/${secret}/tv-schedule/regenerate`, { method: "POST", headers });
+    expect(regenerate.status).toBe(200);
+    const afterRegenerate = await (await SELF.fetch(tvUrl)).json<any>();
+    expect(afterRegenerate.meta.behaviorHints.defaultVideoId).toBe(beforeRegenerate.meta.behaviorHints.defaultVideoId);
+    expect(await env.DB.prepare("SELECT selection_seed FROM channel_state WHERE household_id = ? AND channel = 'tv'")
+      .bind(created.householdId).first<string>("selection_seed")).not.toBe(seedBefore);
+    expect((await env.DB.prepare("SELECT programme_id, next_video_id FROM show_progress ORDER BY programme_id")
+      .all()).results).toEqual(progressBefore.results);
+
+    const currentProgrammeId = await env.DB.prepare("SELECT programme_id FROM current_programmes WHERE household_id = ? AND channel = 'tv'")
+      .bind(created.householdId).first<string>("programme_id");
+    const futureProgrammeId = currentProgrammeId === "active-show-1" ? "active-show-2" : "active-show-1";
+    expect((await SELF.fetch(`https://kids.test/api/households/${secret}/library/${futureProgrammeId}`, { method: "DELETE", headers })).status).toBe(200);
+    const oneShow = await (await SELF.fetch(tvUrl)).json<any>();
+    expect(oneShow.meta.videos).toHaveLength(20);
+    expect(oneShow.meta.videos.every((video: any) => video.id.startsWith(currentProgrammeId === "active-show-1" ? "tt7000001:" : "tt7000002:"))).toBe(true);
+    expect(await env.DB.prepare("SELECT COUNT(*) AS count FROM channel_schedule WHERE programme_id = ?").bind(futureProgrammeId).first())
+      .toMatchObject({ count: 0 });
+
+    const removedVideoId = oneShow.meta.behaviorHints.defaultVideoId;
+    expect((await SELF.fetch(`https://kids.test/api/households/${secret}/library/${currentProgrammeId}`, { method: "DELETE", headers })).status).toBe(200);
+    expect((await (await SELF.fetch(tvUrl)).json<any>()).meta).toBeNull();
+    expect((await SELF.fetch(`${base}/stream/series/${encodeURIComponent(removedVideoId)}.json`)).status).toBe(200);
+  });
+
+  it("removes movies from the remaining rotation and keeps one-item and empty Channel states valid", async () => {
+    const { created, secret, headers, movieUrl } = await arrangeActiveChannels();
+    const before = await (await SELF.fetch(movieUrl)).json<any>();
+    const removedVideoId = before.meta.behaviorHints.defaultVideoId;
+    const removedProgrammeId = await env.DB.prepare("SELECT programme_id FROM current_programmes WHERE household_id = ? AND channel = 'movie'")
+      .bind(created.householdId).first<string>("programme_id");
+
+    expect((await SELF.fetch(`https://kids.test/api/households/${secret}/library/${removedProgrammeId}`, { method: "DELETE", headers })).status).toBe(200);
+    const after = await (await SELF.fetch(movieUrl)).json<any>();
+    expect(after.meta.behaviorHints.defaultVideoId).not.toBe(removedVideoId);
+    expect(await env.DB.prepare("SELECT COUNT(*) AS count FROM movie_rotation WHERE household_id = ? AND programme_id = ?")
+      .bind(created.householdId, removedProgrammeId).first()).toMatchObject({ count: 0 });
+
+    const remaining = await env.DB.prepare("SELECT id FROM approved_programmes WHERE household_id = ? AND content_type = 'movie' ORDER BY id")
+      .bind(created.householdId).all<{ id: string }>();
+    expect((await SELF.fetch(`https://kids.test/api/households/${secret}/library/${remaining.results[0].id}`, { method: "DELETE", headers })).status).toBe(200);
+    const onlyMovie = await (await SELF.fetch(movieUrl)).json<any>();
+    expect(onlyMovie.meta).not.toBeNull();
+
+    expect((await SELF.fetch(`https://kids.test/api/households/${secret}/library/${remaining.results[1].id}`, { method: "DELETE", headers })).status).toBe(200);
+    expect((await (await SELF.fetch(movieUrl)).json<any>()).meta).toBeNull();
+    expect(await env.DB.prepare("SELECT COUNT(*) AS count FROM movie_channel_state WHERE household_id = ?")
+      .bind(created.householdId).first()).toMatchObject({ count: 0 });
   });
 });
 

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -138,6 +138,7 @@ describe("Parent Page Household creation", () => {
     const parentHtml = await parentPage.text();
     expect(parentHtml).toContain("Enter your six-digit PIN");
     expect(parentHtml).toContain("Stremio resolves streams on your device");
+    expect(parentHtml).toContain("fully close and reopen Stremio");
 
     const denied = await SELF.fetch(`https://kids.test/api/households/${secret}/unlock`, {
       method: "POST",
@@ -467,6 +468,7 @@ describe("Approved Library changes while Channels are active", () => {
       method: "PATCH", headers: { ...headers, "content-type": "application/json" }, body: JSON.stringify({ paused: true }),
     });
     expect(pause.status).toBe(200);
+    expect(await pause.json()).toMatchObject({ message: expect.stringContaining("Restart Stremio") });
     const whilePaused = await (await SELF.fetch(tvUrl)).json<any>();
     expect(whilePaused.meta.behaviorHints.defaultVideoId).not.toBe(initialVideoId);
     expect(whilePaused.meta.videos.every((video: any) => !video.id.startsWith(initialVideoId.split(":")[0]))).toBe(true);


### PR DESCRIPTION
## Summary
- add Parent Page controls and authenticated APIs to pause/resume shows, remove approved programmes, and regenerate upcoming TV selections
- reconcile active TV schedules and movie rotations immediately while preserving active client playback, Current Programme during regeneration, and Show Progress
- keep empty and one-item Channels valid and add D1 pause state migration
- cover mutations with Worker integration and Playwright browser tests while both Channels are active
- clearly instruct the Parent to fully restart Stremio after changes and record the accepted in-memory metadata-cache limitation in ADR 0005

## Why
Active schedules previously retained stale selections after Approved Library changes, and deleting a Current Programme could leave Channel state pointing at missing schedule or rotation rows. Reconciliation now rebuilds only eligible future server state; separately installed providers continue any media already playing.

Manual validation also established that Stremio retains identical loaded metadata requests in memory despite `Cache-Control: no-store`. Worker and D1 state changes immediately, but Stremio must fully close and reopen before it displays the refreshed Channel. The Parent accepted this MVP protocol limitation; after restart, removed content cannot be relaunched from the refreshed schedule.

## Validation
- `pnpm typecheck`
- `pnpm test:all`
- `pnpm exec wrangler deploy --dry-run`
- manual local Stremio validation of the accepted restart requirement

Closes #12
