### PR TITLE
Inspect and correct TV Channel state

### DIFF
--- a/migrations/0010_add_tv_advancement_history.sql
+++ b/migrations/0010_add_tv_advancement_history.sql
@@ -1,0 +1,21 @@
+CREATE TABLE tv_advancement_history (
+  id TEXT PRIMARY KEY NOT NULL,
+  household_id TEXT NOT NULL,
+  from_position INTEGER NOT NULL,
+  target_position INTEGER NOT NULL,
+  previous_programme_id TEXT NOT NULL,
+  previous_video_id TEXT NOT NULL,
+  target_programme_id TEXT NOT NULL,
+  target_video_id TEXT NOT NULL,
+  progress_before_json TEXT NOT NULL,
+  progress_after_json TEXT NOT NULL,
+  advanced_at TEXT NOT NULL,
+  undone_at TEXT,
+  undo_owner_token TEXT,
+  FOREIGN KEY (household_id) REFERENCES households(id) ON DELETE CASCADE,
+  FOREIGN KEY (previous_programme_id) REFERENCES approved_programmes(id) ON DELETE CASCADE,
+  FOREIGN KEY (target_programme_id) REFERENCES approved_programmes(id) ON DELETE CASCADE
+);
+
+CREATE INDEX tv_advancement_history_household_idx
+  ON tv_advancement_history (household_id, advanced_at DESC);

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,14 @@ import { movieChannelProgramme, MOVIE_CHANNEL_ID, parseSignOffId, reconcileMovie
 import { issueParentToken, verifyParentToken } from "./secrets";
 import { movieSignOff } from "./sign-off-media";
 import { catalogFor, manifestFor, movieChannelMetadata, TV_CHANNEL_ID, tvChannelMetadata } from "./stremio";
-import { refreshTvChannelSchedule, requestTvProgramme, tvChannelSchedule } from "./tv-channel";
+import {
+  parentTvChannelState,
+  refreshTvChannelSchedule,
+  requestTvProgramme,
+  setShowProgress,
+  tvChannelSchedule,
+  undoLatestTvAdvancement,
+} from "./tv-channel";
 
 export interface Env {
   DB: D1Database;
@@ -64,6 +71,7 @@ function shell(content: string, title = "Kids Channels"): string {
     .programme h3 { margin: 0; } .programme p { margin: .35rem 0; }
     .programme button { width: auto; min-height: 2.5rem; margin-top: .5rem; }
     .eyebrow { color: #65d6ad; font-size: .8rem; font-weight: 800; text-transform: uppercase; }
+    .channel-list { padding-left: 1.5rem; } .channel-list li { margin: .65rem 0; color: #cbd0ea; }
     [hidden] { display: none !important; }
   </style>
 </head>
@@ -140,6 +148,14 @@ function parentPage(secret: string): string {
         <p id="search-status" role="status"></p>
       </form>
       <div id="search-results"></div>
+      <h2>TV Channel</h2>
+      <p id="tv-current">No Current Programme.</p>
+      <button id="undo-tv" type="button" class="secondary" hidden>Undo most recent advancement</button>
+      <h3>Channel Schedule</h3>
+      <ol id="tv-schedule" class="channel-list"><li>No programmes scheduled.</li></ol>
+      <h3>Recently played</h3>
+      <ol id="tv-history" class="channel-list"><li>No recent playback.</li></ol>
+      <p id="tv-status" role="status"></p>
       <h2>Approved Library</h2>
       <p class="notice">Stremio keeps Channel details in memory. After changing the Approved Library or regenerating selections, fully close and reopen Stremio to load the updated Channel.</p>
       <button id="regenerate-tv" type="button" class="secondary">Regenerate upcoming TV selections</button>
@@ -160,9 +176,18 @@ function parentPage(secret: string): string {
         const metadata = document.createElement('p'); metadata.textContent = [programme.releaseInfo, (programme.genres || []).join(', '), programme.imdbRating ? 'IMDb ' + programme.imdbRating : ''].filter(Boolean).join(' · ');
         const description = document.createElement('p'); description.textContent = programme.description || 'No description available.';
         details.append(kind, heading, metadata, description);
-        if (approved && programme.showProgress) {
-          const progress = document.createElement('p'); progress.textContent = 'Starts at S' + String(programme.showProgress.season).padStart(2, '0') + 'E' + String(programme.showProgress.episode).padStart(2, '0') + ' — ' + programme.showProgress.title;
-          details.append(progress);
+        if (approved && programme.type === 'show') {
+          const progress = document.createElement('p');
+          progress.textContent = programme.showProgress
+            ? 'Show Progress: ' + episodeLabel(programme.showProgress)
+            : 'Finished';
+          const episode = document.createElement('select'); episode.setAttribute('aria-label', 'Next episode for ' + programme.title);
+          programme.episodes.forEach(item => { const option = document.createElement('option'); option.value = item.id; option.textContent = episodeLabel(item); episode.append(option); });
+          episode.value = programme.showProgress?.id || programme.episodes[0]?.id || '';
+          const correct = document.createElement('button'); correct.type = 'button';
+          correct.textContent = programme.showProgress ? 'Set Show Progress' : 'Restart show';
+          correct.addEventListener('click', () => correctProgress(programme.id, episode.value, correct));
+          details.append(progress, episode, correct);
         }
         if (approved) {
           if (programme.type === 'show') {
@@ -177,6 +202,25 @@ function parentPage(secret: string): string {
         }
         card.append(image, details); return {card, details};
       }
+      function episodeLabel(episode) {
+        return 'S' + String(episode.season).padStart(2, '0') + 'E' + String(episode.episode).padStart(2, '0') + ' — ' + episode.title;
+      }
+      async function loadTvState() {
+        const response = await fetch('/api/households/${secret}/tv-state', {headers: headers()});
+        const result = await response.json(); if (!response.ok) return;
+        document.querySelector('#tv-current').textContent = result.current
+          ? result.current.showTitle + ' — ' + episodeLabel(result.current.episode)
+          : 'No Current Programme.';
+        const schedule = document.querySelector('#tv-schedule'); schedule.replaceChildren();
+        (result.schedule.length ? result.schedule : [{empty: 'No programmes scheduled.'}]).forEach(item => {
+          const row = document.createElement('li'); row.textContent = item.empty || item.showTitle + ' — ' + episodeLabel(item.episode); schedule.append(row);
+        });
+        const history = document.querySelector('#tv-history'); history.replaceChildren();
+        (result.recentPlayback.length ? result.recentPlayback : [{empty: 'No recent playback.'}]).forEach(item => {
+          const row = document.createElement('li'); row.textContent = item.empty || item.showTitle + ' — ' + episodeLabel(item.episode); history.append(row);
+        });
+        document.querySelector('#undo-tv').hidden = !result.canUndo;
+      }
       async function loadLibrary() {
         const response = await fetch('/api/households/${secret}/library', {headers: headers()});
         const result = await response.json(); const output = document.querySelector('#library'); output.replaceChildren();
@@ -190,14 +234,23 @@ function parentPage(secret: string): string {
         });
         const result = await response.json();
         if (!response.ok) { button.disabled = false; document.querySelector('#library-status').textContent = result.error; return; }
-        document.querySelector('#library-status').textContent = result.message; await loadLibrary();
+        document.querySelector('#library-status').textContent = result.message; await Promise.all([loadLibrary(), loadTvState()]);
+      }
+      async function correctProgress(programmeId, videoId, button) {
+        button.disabled = true;
+        const response = await fetch('/api/households/${secret}/library/' + encodeURIComponent(programmeId) + '/progress', {
+          method: 'PATCH', headers: {...headers(), 'content-type': 'application/json'}, body: JSON.stringify({videoId})
+        });
+        const result = await response.json(); button.disabled = false;
+        document.querySelector('#library-status').textContent = response.ok ? result.message : result.error;
+        if (response.ok) await Promise.all([loadLibrary(), loadTvState()]);
       }
       async function removeProgramme(programmeId, button) {
         button.disabled = true;
         const response = await fetch('/api/households/${secret}/library/' + encodeURIComponent(programmeId), {method: 'DELETE', headers: headers()});
         const result = await response.json();
         if (!response.ok) { button.disabled = false; document.querySelector('#library-status').textContent = result.error; return; }
-        document.querySelector('#library-status').textContent = result.message; await loadLibrary();
+        document.querySelector('#library-status').textContent = result.message; await Promise.all([loadLibrary(), loadTvState()]);
       }
       async function approve(programme, startingEpisodeId, button) {
         button.disabled = true;
@@ -207,7 +260,7 @@ function parentPage(secret: string): string {
         });
         const result = await response.json();
         if (!response.ok) { button.disabled = false; button.textContent = result.error; return; }
-        button.textContent = 'Approved'; await loadLibrary();
+        button.textContent = 'Approved'; await Promise.all([loadLibrary(), loadTvState()]);
       }
       function showSearchResult(programme) {
         const built = programmeCard(programme, false); const button = document.createElement('button');
@@ -234,13 +287,21 @@ function parentPage(secret: string): string {
         if (!response.ok) { document.querySelector('#error').textContent = result.error; return; }
         parentToken = result.parentToken; document.querySelector('#install').href = result.installUrl;
         document.querySelector('#manifest').textContent = result.manifestUrl;
-        form.hidden = true; document.querySelector('#result').hidden = false; await loadLibrary();
+        form.hidden = true; document.querySelector('#result').hidden = false; await Promise.all([loadLibrary(), loadTvState()]);
       });
       document.querySelector('#regenerate-tv').addEventListener('click', async (event) => {
         const button = event.currentTarget; button.disabled = true;
         const response = await fetch('/api/households/${secret}/tv-schedule/regenerate', {method: 'POST', headers: headers()});
         const result = await response.json(); button.disabled = false;
         document.querySelector('#library-status').textContent = response.ok ? result.message : result.error;
+        if (response.ok) await loadTvState();
+      });
+      document.querySelector('#undo-tv').addEventListener('click', async (event) => {
+        const button = event.currentTarget; button.disabled = true;
+        const response = await fetch('/api/households/${secret}/tv-schedule/undo', {method: 'POST', headers: headers()});
+        const result = await response.json(); button.disabled = false;
+        document.querySelector('#tv-status').textContent = response.ok ? result.message : result.error;
+        if (response.ok) await Promise.all([loadLibrary(), loadTvState()]);
       });
       document.querySelector('#search-form').addEventListener('submit', async (event) => {
         event.preventDefault(); const status = document.querySelector('#search-status'); status.textContent = 'Searching Cinemeta…';
@@ -287,7 +348,7 @@ export default {
     const path = url.pathname;
 
     if (request.method === "OPTIONS") {
-      return new Response(null, { status: 204, headers: { ...jsonHeaders, "access-control-allow-methods": "GET, POST, PUT, OPTIONS", "access-control-allow-headers": "content-type, authorization" } });
+      return new Response(null, { status: 204, headers: { ...jsonHeaders, "access-control-allow-methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS", "access-control-allow-headers": "content-type, authorization" } });
     }
 
     if (request.method === "GET" && path === "/") return html(homePage());
@@ -418,6 +479,46 @@ export default {
         await reconcileMovieChannel(env.DB, household.id, env.MOVIE_ROTATION_SEED);
       }
       return json({ message: `${programme.content_type === "show" ? "Show" : "Movie"} removed from future Channel selections. Restart Stremio to refresh the Channel.` });
+    }
+
+    const tvStateMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/tv-state$/);
+    if (request.method === "GET" && tvStateMatch) {
+      const household = await findHousehold(env.DB, tvStateMatch[1]);
+      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household.id, env.CONFIG_SECRET))) {
+        return json({ error: "Parent authentication is required." }, 401);
+      }
+      return json(await parentTvChannelState(env.DB, household.id, env.TV_SCHEDULE_SEED));
+    }
+
+    const progressMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/library\/([A-Za-z0-9-]+)\/progress$/);
+    if (request.method === "PATCH" && progressMatch) {
+      const household = await findHousehold(env.DB, progressMatch[1]);
+      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household.id, env.CONFIG_SECRET))) {
+        return json({ error: "Parent authentication is required." }, 401);
+      }
+      let input: { videoId?: unknown } = {};
+      try { input = await request.json() as typeof input; } catch { /* handled below */ }
+      if (typeof input.videoId !== "string") return json({ error: "Choose a valid regular released episode." }, 400);
+      try {
+        await setShowProgress(env.DB, household.id, progressMatch[2], input.videoId, env.TV_SCHEDULE_SEED);
+      } catch (error) {
+        if (error instanceof Error && error.message === "episode is invalid") {
+          return json({ error: "Choose a valid regular released episode for this show." }, 400);
+        }
+        throw error;
+      }
+      return json({ message: "Show Progress corrected and incompatible future selections repaired. The active stream was not interrupted. Restart Stremio to refresh the Channel." });
+    }
+
+    const undoMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/tv-schedule\/undo$/);
+    if (request.method === "POST" && undoMatch) {
+      const household = await findHousehold(env.DB, undoMatch[1]);
+      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household.id, env.CONFIG_SECRET))) {
+        return json({ error: "Parent authentication is required." }, 401);
+      }
+      const undone = await undoLatestTvAdvancement(env.DB, household.id, env.TV_SCHEDULE_SEED);
+      if (!undone) return json({ error: "There is no latest TV advancement to undo." }, 409);
+      return json({ message: "Most recent advancement undone without changing later corrections to other shows. The active stream was not interrupted. Restart Stremio to refresh the Channel." });
     }
 
     const regenerateMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/tv-schedule\/regenerate$/);

--- a/src/tv-channel.ts
+++ b/src/tv-channel.ts
@@ -46,6 +46,32 @@ interface StateRow {
   selection_seed: string;
 }
 
+interface AdvancementHistoryRow {
+  id: string;
+  from_position: number;
+  target_position: number;
+  previous_programme_id: string;
+  previous_video_id: string;
+  target_programme_id: string;
+  target_video_id: string;
+  progress_before_json: string;
+  progress_after_json: string;
+  advanced_at: string;
+}
+
+export interface TvPlaybackHistoryItem {
+  showTitle: string;
+  episode: CinemetaEpisode;
+  playedAt: string;
+}
+
+export interface ParentTvChannelState {
+  current?: TvScheduledProgramme;
+  schedule: TvScheduledProgramme[];
+  recentPlayback: TvPlaybackHistoryItem[];
+  canUndo: boolean;
+}
+
 interface Show {
   programmeId: string;
   imdbId: string;
@@ -133,9 +159,11 @@ function project(
   startPosition: number,
   count: number,
   existing: Array<{ programmeId: string; videoId: string }> = [],
+  initialPreviousProgrammeId?: string,
+  blockedVideoIds: ReadonlySet<string> = new Set(),
 ): TvScheduledProgramme[] {
   const cursors = new Map(shows.map((show) => [show.programmeId, show.progressIndex]));
-  let previousProgrammeId: string | undefined;
+  let previousProgrammeId = initialPreviousProgrammeId;
 
   for (const item of existing) {
     const show = shows.find((candidate) => candidate.programmeId === item.programmeId);
@@ -147,6 +175,11 @@ function project(
 
   const scheduled: TvScheduledProgramme[] = [];
   for (let offset = 0; offset < count; offset += 1) {
+    for (const show of shows) {
+      let cursor = cursors.get(show.programmeId) ?? show.episodes.length;
+      while (cursor < show.episodes.length && blockedVideoIds.has(show.episodes[cursor].id)) cursor += 1;
+      cursors.set(show.programmeId, cursor);
+    }
     const eligible = shows.filter((show) => (cursors.get(show.programmeId) ?? show.episodes.length) < show.episodes.length);
     if (eligible.length === 0) break;
     const alternatives = eligible.length > 1
@@ -260,10 +293,14 @@ async function advanceOnce(
     programme.position >= currentState.current_position && programme.position < target.position);
   const retained = currentSchedule.filter((programme) => programme.position >= target.position);
   const shows = await loadShows(db, householdId);
+  const progressBefore: Record<string, string | null> = {};
+  const progressAfter: Record<string, string | null> = {};
   for (const show of shows) {
     const skipped = bypassed.filter((programme) => programme.programmeId === show.programmeId);
     if (skipped.length === 0) continue;
+    progressBefore[show.programmeId] = show.episodes[show.progressIndex]?.id ?? null;
     show.progressIndex = show.episodes.findIndex((episode) => episode.id === skipped[skipped.length - 1].episode.id) + 1;
+    progressAfter[show.programmeId] = show.episodes[show.progressIndex]?.id ?? null;
   }
   const appendCount = TV_SCHEDULE_LENGTH - retained.length;
   const appended = project(
@@ -278,10 +315,18 @@ async function advanceOnce(
   const owns = `EXISTS (SELECT 1 FROM channel_advancements claim
     WHERE claim.household_id = ? AND claim.channel = 'tv' AND claim.from_position = ? AND claim.owner_token = ?)`;
   const ownership = [householdId, currentState.current_position, owner] as const;
+  const previous = bypassed[0];
   const statements: D1PreparedStatement[] = [
     db.prepare(`INSERT OR IGNORE INTO channel_advancements
       (household_id, channel, from_position, target_position, owner_token, advanced_at)
       VALUES (?, 'tv', ?, ?, ?, ?)`).bind(householdId, currentState.current_position, target.position, owner, now),
+    db.prepare(`INSERT INTO tv_advancement_history
+      (id, household_id, from_position, target_position, previous_programme_id, previous_video_id,
+       target_programme_id, target_video_id, progress_before_json, progress_after_json, advanced_at)
+      SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? WHERE ${owns}`)
+      .bind(owner, householdId, currentState.current_position, target.position,
+        previous.programmeId, previous.episode.id, target.programmeId, target.episode.id,
+        JSON.stringify(progressBefore), JSON.stringify(progressAfter), now, ...ownership),
   ];
 
   for (const show of shows) {
@@ -358,10 +403,17 @@ export async function refreshTvChannelSchedule(
       poster: currentShow.poster,
       background: currentShow.background,
       episode: currentEpisode,
-    }, ...project(shows, seed, position + 1, TV_SCHEDULE_LENGTH - 1, [{
-      programmeId: currentShow.programmeId,
-      videoId: currentEpisode.id,
-    }])]
+    }, ...project(
+      shows,
+      seed,
+      position + 1,
+      TV_SCHEDULE_LENGTH - 1,
+      currentShow.episodes[currentShow.progressIndex]?.id === currentEpisode.id
+        ? [{ programmeId: currentShow.programmeId, videoId: currentEpisode.id }]
+        : [],
+      currentShow.programmeId,
+      new Set([currentEpisode.id]),
+    )]
     : project(shows, seed, position, TV_SCHEDULE_LENGTH);
 
   if (programmes.length === 0) return [];
@@ -385,6 +437,114 @@ export async function refreshTvChannelSchedule(
   }
   await db.batch(statements);
   return scheduleRows(db, householdId);
+}
+
+export async function parentTvChannelState(
+  db: D1Database,
+  householdId: string,
+  configuredSeed?: string,
+): Promise<ParentTvChannelState> {
+  const schedule = await tvChannelSchedule(db, householdId, configuredSeed);
+  const history = await db.prepare(`SELECT programme.title AS show_title,
+      episode.video_id, episode.season, episode.episode, episode.title, episode.released_at, episode.overview,
+      history.advanced_at
+    FROM tv_advancement_history history
+    JOIN approved_programmes programme ON programme.id = history.previous_programme_id
+    JOIN show_episodes episode ON episode.programme_id = history.previous_programme_id
+      AND episode.video_id = history.previous_video_id
+    WHERE history.household_id = ?
+    ORDER BY history.advanced_at DESC LIMIT 10`).bind(householdId).all<Record<string, unknown>>();
+  const canUndo = Boolean(await db.prepare(`SELECT 1 FROM tv_advancement_history history
+    JOIN channel_state state ON state.household_id = history.household_id AND state.channel = 'tv'
+    WHERE history.household_id = ? AND history.undone_at IS NULL
+      AND history.target_position = state.current_position
+    ORDER BY history.advanced_at DESC LIMIT 1`).bind(householdId).first());
+  return {
+    current: schedule[0],
+    schedule,
+    recentPlayback: history.results.map((row) => ({
+      showTitle: row.show_title as string,
+      episode: episodeFromRow({
+        programme_id: "",
+        video_id: row.video_id as string,
+        season: row.season as number,
+        episode: row.episode as number,
+        episode_title: row.title as string,
+        released_at: row.released_at as string,
+        overview: row.overview as string | null,
+      }),
+      playedAt: row.advanced_at as string,
+    })),
+    canUndo,
+  };
+}
+
+export async function setShowProgress(
+  db: D1Database,
+  householdId: string,
+  programmeId: string,
+  videoId: string,
+  configuredSeed?: string,
+): Promise<void> {
+  const episode = await db.prepare(`SELECT episode.video_id FROM show_episodes episode
+    JOIN approved_programmes programme ON programme.id = episode.programme_id
+    WHERE programme.household_id = ? AND programme.id = ? AND programme.content_type = 'show'
+      AND episode.video_id = ?`).bind(householdId, programmeId, videoId).first();
+  if (!episode) throw new Error("episode is invalid");
+  await db.prepare(`INSERT INTO show_progress (programme_id, next_video_id) VALUES (?, ?)
+    ON CONFLICT(programme_id) DO UPDATE SET next_video_id = excluded.next_video_id`)
+    .bind(programmeId, videoId).run();
+  await refreshTvChannelSchedule(db, householdId, false, configuredSeed);
+}
+
+export async function undoLatestTvAdvancement(
+  db: D1Database,
+  householdId: string,
+  configuredSeed?: string,
+): Promise<boolean> {
+  const history = await db.prepare(`SELECT history.* FROM tv_advancement_history history
+    JOIN channel_state state ON state.household_id = history.household_id AND state.channel = 'tv'
+    WHERE history.household_id = ? AND history.undone_at IS NULL
+      AND history.target_position = state.current_position
+    ORDER BY history.advanced_at DESC LIMIT 1`).bind(householdId).first<AdvancementHistoryRow>();
+  if (!history) return false;
+
+  const before = JSON.parse(history.progress_before_json) as Record<string, string | null>;
+  const after = JSON.parse(history.progress_after_json) as Record<string, string | null>;
+  const now = new Date().toISOString();
+  const undoOwner = crypto.randomUUID();
+  const ownsUndo = "EXISTS (SELECT 1 FROM tv_advancement_history WHERE id = ? AND undo_owner_token = ?)";
+  const ownership = [history.id, undoOwner] as const;
+  const statements: D1PreparedStatement[] = [
+    db.prepare(`UPDATE tv_advancement_history SET undone_at = ?, undo_owner_token = ?
+      WHERE id = ? AND undone_at IS NULL AND EXISTS (
+        SELECT 1 FROM channel_state WHERE household_id = ? AND channel = 'tv' AND current_position = ?)`)
+      .bind(now, undoOwner, history.id, householdId, history.target_position),
+  ];
+  for (const [programmeId, previousVideoId] of Object.entries(before)) {
+    const expectedVideoId = after[programmeId];
+    if (previousVideoId === null) continue;
+    if (expectedVideoId === null) {
+      statements.push(db.prepare(`INSERT INTO show_progress (programme_id, next_video_id)
+        SELECT ?, ? WHERE ${ownsUndo} AND NOT EXISTS (SELECT 1 FROM show_progress WHERE programme_id = ?)`)
+        .bind(programmeId, previousVideoId, ...ownership, programmeId));
+    } else {
+      statements.push(db.prepare(`UPDATE show_progress SET next_video_id = ?
+        WHERE programme_id = ? AND next_video_id = ? AND ${ownsUndo}`)
+        .bind(previousVideoId, programmeId, expectedVideoId, ...ownership));
+    }
+  }
+  statements.push(
+    db.prepare(`UPDATE channel_state SET current_position = ?
+      WHERE household_id = ? AND channel = 'tv' AND current_position = ? AND ${ownsUndo}`)
+      .bind(history.from_position, householdId, history.target_position, ...ownership),
+    db.prepare(`UPDATE current_programmes SET programme_id = ?, video_id = ?, selected_at = ?
+      WHERE household_id = ? AND channel = 'tv' AND ${ownsUndo}`)
+      .bind(history.previous_programme_id, history.previous_video_id, now, householdId, ...ownership),
+  );
+  await db.batch(statements);
+  await refreshTvChannelSchedule(db, householdId, false, configuredSeed);
+  return true;
 }
 
 export async function requestTvProgramme(

--- a/test/browser/approved-library.spec.ts
+++ b/test/browser/approved-library.spec.ts
@@ -48,7 +48,7 @@ test("a Parent searches Cinemeta and approves a movie and a show from another st
   await show.getByRole("button", { name: "Approve show" }).click();
 
   const approvedShow = page.locator("#library .programme").filter({ hasText: "The Example" });
-  await expect(approvedShow).toContainText("Starts at S01E02 — Second");
+  await expect(approvedShow).toContainText("Show Progress: S01E02 — Second");
 
   const manifestUrl = await page.locator("#manifest").textContent();
   expect(manifestUrl).toBeTruthy();
@@ -77,6 +77,24 @@ test("a Parent searches Cinemeta and approves a movie and a show from another st
   await expect(page.locator("#library-status")).toContainText("without changing the Current Programme or Show Progress");
   await expect(page.locator("#library-status")).toContainText("Restart Stremio");
   expect((await channelMetadata()).tv.meta?.behaviorHints.defaultVideoId).toBe("tt1234567:1:2");
+  await expect(page.locator("#tv-current")).toContainText("The Example — S01E02 — Second");
+  await expect(page.locator("#tv-schedule li").first()).toContainText("The Example — S01E02 — Second");
+
+  const progressShow = page.locator("#library .programme").filter({ hasText: "The Example" });
+  await progressShow.getByRole("combobox", { name: "Next episode for The Example" }).selectOption("tt1234567:1:1");
+  await progressShow.getByRole("button", { name: "Set Show Progress" }).click();
+  await expect(page.locator("#library-status")).toContainText("incompatible future selections repaired");
+  await expect(page.locator("#tv-current")).toContainText("S01E02 — Second");
+  await expect(page.locator("#tv-schedule li").nth(1)).toContainText("S01E01 — First");
+
+  await page.evaluate(async (base) => {
+    await fetch(base + "/stream/series/" + encodeURIComponent("tt1234567:1:1") + ".json");
+    await (globalThis as unknown as { loadTvState(): Promise<void> }).loadTvState();
+  }, addonBase);
+  await expect(page.locator("#tv-history")).toContainText("S01E02 — Second");
+  await page.getByRole("button", { name: "Undo most recent advancement" }).click();
+  await expect(page.locator("#tv-status")).toContainText("Most recent advancement undone");
+  await expect(page.locator("#tv-current")).toContainText("S01E02 — Second");
 
   await page.locator("#library .programme").filter({ hasText: "The Example" })
     .getByRole("button", { name: "Remove show" }).click();

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -50,6 +50,12 @@ beforeEach(async () => {
     target_position INTEGER NOT NULL, owner_token TEXT NOT NULL, advanced_at TEXT NOT NULL,
     PRIMARY KEY (household_id, channel, from_position)
   )`).run();
+  await env.DB.prepare(`CREATE TABLE IF NOT EXISTS tv_advancement_history (
+    id TEXT PRIMARY KEY NOT NULL, household_id TEXT NOT NULL, from_position INTEGER NOT NULL,
+    target_position INTEGER NOT NULL, previous_programme_id TEXT NOT NULL, previous_video_id TEXT NOT NULL,
+    target_programme_id TEXT NOT NULL, target_video_id TEXT NOT NULL, progress_before_json TEXT NOT NULL,
+    progress_after_json TEXT NOT NULL, advanced_at TEXT NOT NULL, undone_at TEXT, undo_owner_token TEXT
+  )`).run();
   await env.DB.prepare(`CREATE TABLE IF NOT EXISTS movie_channel_state (
     household_id TEXT PRIMARY KEY NOT NULL, cycle INTEGER NOT NULL, current_position INTEGER NOT NULL,
     selection_seed TEXT NOT NULL, initialized_at TEXT NOT NULL
@@ -68,6 +74,7 @@ beforeEach(async () => {
   await env.DB.prepare("DELETE FROM movie_advancements").run();
   await env.DB.prepare("DELETE FROM movie_rotation").run();
   await env.DB.prepare("DELETE FROM movie_channel_state").run();
+  await env.DB.prepare("DELETE FROM tv_advancement_history").run();
   await env.DB.prepare("DELETE FROM channel_advancements").run();
   await env.DB.prepare("DELETE FROM channel_schedule").run();
   await env.DB.prepare("DELETE FROM channel_state").run();
@@ -346,6 +353,14 @@ describe("rolling TV Channel Schedule", () => {
     return (await SELF.fetch(`${base}/meta/series/${encodeURIComponent("kids-channels:tv")}.json`)).json<any>();
   }
 
+  async function parentHeaders(created: CreatedHousehold) {
+    const response = await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/unlock`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ pin: "123456" }),
+    });
+    const { parentToken } = await response.json<{ parentToken: string }>();
+    return { authorization: `Bearer ${parentToken}` };
+  }
+
   it("alternates eligible shows deterministically and inspects twenty programmes without advancing Show Progress", async () => {
     const { base } = await arrangeShows(3);
     const metadataResponse = await SELF.fetch(`${base}/meta/series/${encodeURIComponent("kids-channels:tv")}.json`);
@@ -390,6 +405,83 @@ describe("rolling TV Channel Schedule", () => {
     expect(await env.DB.prepare("SELECT COUNT(*) AS count FROM channel_advancements").first()).toMatchObject({ count: 1 });
     expect(await env.DB.prepare("SELECT COUNT(*) AS count FROM channel_schedule").first()).toMatchObject({ count: 20 });
     expect(await env.DB.prepare("SELECT COUNT(DISTINCT video_id) AS count FROM channel_schedule").first()).toMatchObject({ count: 20 });
+  });
+
+  it("displays Current Programme, Channel Schedule, and recent playback only to the Parent", async () => {
+    const { created, base } = await arrangeShows(2);
+    expect((await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/tv-state`)).status).toBe(401);
+    const before = await metadata(base);
+    await SELF.fetch(`${base}/stream/series/${encodeURIComponent(before.meta.videos[1].id)}.json`);
+
+    const response = await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/tv-state`, {
+      headers: await parentHeaders(created),
+    });
+    const state = await response.json<any>();
+    expect(state.current.episode.id).toBe(before.meta.videos[1].id);
+    expect(state.schedule).toHaveLength(20);
+    expect(state.recentPlayback[0]).toMatchObject({ showTitle: expect.stringMatching(/^Show /), episode: { id: before.meta.videos[0].id } });
+    expect(state.canUndo).toBe(true);
+    expect(JSON.stringify(state)).not.toContain(secretFrom(created));
+  });
+
+  it("corrects Show Progress, repairs incompatible future entries, and preserves the Current Programme", async () => {
+    const { created, base } = await arrangeShows(2, 8);
+    const before = await metadata(base);
+    const currentId = before.meta.behaviorHints.defaultVideoId;
+    const headers = await parentHeaders(created);
+    const response = await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/library/programme-1/progress`, {
+      method: "PATCH", headers: { ...headers, "content-type": "application/json" },
+      body: JSON.stringify({ videoId: "tt9000001:1:5" }),
+    });
+    expect(response.status).toBe(200);
+    const after = await metadata(base);
+    expect(after.meta.behaviorHints.defaultVideoId).toBe(currentId);
+    const futureShowOne = after.meta.videos.slice(1).filter((video: any) => video.id.startsWith("tt9000001:"));
+    expect(futureShowOne.length).toBeGreaterThan(0);
+    expect(futureShowOne.every((video: any) => Number(video.id.split(":")[2]) >= 5)).toBe(true);
+    expect(await env.DB.prepare("SELECT next_video_id FROM show_progress WHERE programme_id = 'programme-1'").first())
+      .toMatchObject({ next_video_id: "tt9000001:1:5" });
+  });
+
+  it("undoes only the latest advancement and does not overwrite another show's later correction", async () => {
+    const { created, base } = await arrangeShows(2, 8);
+    const before = await metadata(base);
+    await SELF.fetch(`${base}/stream/series/${encodeURIComponent(before.meta.videos[1].id)}.json`);
+    const headers = await parentHeaders(created);
+    const priorShow = before.meta.videos[0].id.startsWith("tt9000001:") ? "programme-1" : "programme-2";
+    const otherShow = priorShow === "programme-1" ? "programme-2" : "programme-1";
+    const otherImdb = otherShow === "programme-1" ? "tt9000001" : "tt9000002";
+    await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/library/${otherShow}/progress`, {
+      method: "PATCH", headers: { ...headers, "content-type": "application/json" },
+      body: JSON.stringify({ videoId: `${otherImdb}:1:6` }),
+    });
+    const undo = await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/tv-schedule/undo`, { method: "POST", headers });
+    expect(undo.status).toBe(200);
+    expect((await metadata(base)).meta.behaviorHints.defaultVideoId).toBe(before.meta.videos[0].id);
+    expect(await env.DB.prepare("SELECT next_video_id FROM show_progress WHERE programme_id = ?").bind(otherShow).first())
+      .toMatchObject({ next_video_id: `${otherImdb}:1:6` });
+    expect((await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/tv-schedule/undo`, { method: "POST", headers })).status).toBe(409);
+  });
+
+  it("marks exhausted shows Finished and lets the Parent restart them", async () => {
+    const { created, base } = await arrangeShows(2, 2);
+    const before = await metadata(base);
+    const lastShowOne = before.meta.videos.findIndex((video: any) => video.id === "tt9000001:1:2");
+    expect(lastShowOne).toBeGreaterThanOrEqual(0);
+    const target = before.meta.videos[lastShowOne + 1];
+    expect(target).toBeTruthy();
+    await SELF.fetch(`${base}/stream/series/${encodeURIComponent(target.id)}.json`);
+    expect(await env.DB.prepare("SELECT next_video_id FROM show_progress WHERE programme_id = 'programme-1'").first()).toBeNull();
+    const exhausted = await metadata(base);
+    expect(exhausted.meta.videos.slice(1).every((video: any) => !video.id.startsWith("tt9000001:"))).toBe(true);
+
+    const headers = await parentHeaders(created);
+    const restart = await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/library/programme-1/progress`, {
+      method: "PATCH", headers: { ...headers, "content-type": "application/json" },
+      body: JSON.stringify({ videoId: "tt9000001:1:1" }),
+    });
+    expect(restart.status).toBe(200);
+    expect((await metadata(base)).meta.videos.slice(1).some((video: any) => video.id === "tt9000001:1:1")).toBe(true);
   });
 
   it("plays a distant visible programme and treats every bypassed programme as skipped", async () => {


### PR DESCRIPTION
## Summary
- display the TV Current Programme, upcoming Channel Schedule, and recent playback on the authenticated Parent Page
- let Parents correct or restart Show Progress and safely undo the latest advancement
- persist advancement snapshots so exhausted shows become Finished and undo preserves unrelated corrections
- repair future schedules without interrupting the active stream
- cover state display, correction, undo, exhaustion, and restart in Worker and browser tests

## Testing
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:browser`
- `git diff --check`

Closes #13
