### PR TITLE
Manage the movie rotation from the Parent Page

### DIFF
--- a/migrations/0011_add_movie_rotation_management.sql
+++ b/migrations/0011_add_movie_rotation_management.sql
@@ -1,0 +1,25 @@
+ALTER TABLE movie_channel_state ADD COLUMN revision INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE movie_channel_mutations (
+  household_id TEXT NOT NULL,
+  revision INTEGER NOT NULL,
+  owner_token TEXT NOT NULL,
+  claimed_at TEXT NOT NULL,
+  PRIMARY KEY (household_id, revision),
+  FOREIGN KEY (household_id) REFERENCES households(id) ON DELETE CASCADE
+);
+
+CREATE TABLE movie_playback_history (
+  id TEXT PRIMARY KEY NOT NULL,
+  household_id TEXT NOT NULL,
+  programme_id TEXT NOT NULL,
+  imdb_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  cycle INTEGER NOT NULL,
+  position INTEGER NOT NULL,
+  played_at TEXT NOT NULL,
+  FOREIGN KEY (household_id) REFERENCES households(id) ON DELETE CASCADE
+);
+
+CREATE INDEX movie_playback_history_household_idx
+  ON movie_playback_history (household_id, played_at DESC);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,16 @@
 import { approveProgramme, approvedLibrary, hasApprovedProgramme } from "./approved-library";
 import { CinemetaClient, type ContentType } from "./cinemeta";
 import { createHousehold, findHousehold, validPin, verifyPin } from "./households";
-import { movieChannelProgramme, MOVIE_CHANNEL_ID, parseSignOffId, reconcileMovieChannel, requestMovieSignOff } from "./movie-channel";
+import {
+  movieChannelProgramme,
+  MOVIE_CHANNEL_ID,
+  parentMovieChannelState,
+  parseSignOffId,
+  reconcileMovieChannel,
+  removeApprovedMovie,
+  requestMovieSignOff,
+  resetMovieRotation,
+} from "./movie-channel";
 import { issueParentToken, verifyParentToken } from "./secrets";
 import { movieSignOff } from "./sign-off-media";
 import { catalogFor, manifestFor, movieChannelMetadata, TV_CHANNEL_ID, tvChannelMetadata } from "./stremio";
@@ -156,6 +165,14 @@ function parentPage(secret: string): string {
       <h3>Recently played</h3>
       <ol id="tv-history" class="channel-list"><li>No recent playback.</li></ol>
       <p id="tv-status" role="status"></p>
+      <h2>Movie Channel</h2>
+      <p id="movie-current">No Current Programme.</p>
+      <h3>Remaining rotation</h3>
+      <ol id="movie-rotation" class="channel-list"><li>No movies remaining.</li></ol>
+      <h3>Recently played</h3>
+      <ol id="movie-history" class="channel-list"><li>No recent playback.</li></ol>
+      <button id="reset-movies" type="button" class="secondary">Reset movie rotation</button>
+      <p id="movie-status" role="status"></p>
       <h2>Approved Library</h2>
       <p class="notice">Stremio keeps Channel details in memory. After changing the Approved Library or regenerating selections, fully close and reopen Stremio to load the updated Channel.</p>
       <button id="regenerate-tv" type="button" class="secondary">Regenerate upcoming TV selections</button>
@@ -221,6 +238,21 @@ function parentPage(secret: string): string {
         });
         document.querySelector('#undo-tv').hidden = !result.canUndo;
       }
+      async function loadMovieState() {
+        const response = await fetch('/api/households/${secret}/movie-state', {headers: headers()});
+        const result = await response.json(); if (!response.ok) return;
+        document.querySelector('#movie-current').textContent = result.current
+          ? result.current.title
+          : 'No Current Programme.';
+        const rotation = document.querySelector('#movie-rotation'); rotation.replaceChildren();
+        (result.remaining.length ? result.remaining : [{empty: 'No movies remaining.'}]).forEach(item => {
+          const row = document.createElement('li'); row.textContent = item.empty || item.title; rotation.append(row);
+        });
+        const history = document.querySelector('#movie-history'); history.replaceChildren();
+        (result.recentPlayback.length ? result.recentPlayback : [{empty: 'No recent playback.'}]).forEach(item => {
+          const row = document.createElement('li'); row.textContent = item.empty || item.title; history.append(row);
+        });
+      }
       async function loadLibrary() {
         const response = await fetch('/api/households/${secret}/library', {headers: headers()});
         const result = await response.json(); const output = document.querySelector('#library'); output.replaceChildren();
@@ -234,7 +266,7 @@ function parentPage(secret: string): string {
         });
         const result = await response.json();
         if (!response.ok) { button.disabled = false; document.querySelector('#library-status').textContent = result.error; return; }
-        document.querySelector('#library-status').textContent = result.message; await Promise.all([loadLibrary(), loadTvState()]);
+        document.querySelector('#library-status').textContent = result.message; await Promise.all([loadLibrary(), loadTvState(), loadMovieState()]);
       }
       async function correctProgress(programmeId, videoId, button) {
         button.disabled = true;
@@ -250,7 +282,7 @@ function parentPage(secret: string): string {
         const response = await fetch('/api/households/${secret}/library/' + encodeURIComponent(programmeId), {method: 'DELETE', headers: headers()});
         const result = await response.json();
         if (!response.ok) { button.disabled = false; document.querySelector('#library-status').textContent = result.error; return; }
-        document.querySelector('#library-status').textContent = result.message; await Promise.all([loadLibrary(), loadTvState()]);
+        document.querySelector('#library-status').textContent = result.message; await Promise.all([loadLibrary(), loadTvState(), loadMovieState()]);
       }
       async function approve(programme, startingEpisodeId, button) {
         button.disabled = true;
@@ -260,7 +292,7 @@ function parentPage(secret: string): string {
         });
         const result = await response.json();
         if (!response.ok) { button.disabled = false; button.textContent = result.error; return; }
-        button.textContent = 'Approved'; await Promise.all([loadLibrary(), loadTvState()]);
+        button.textContent = 'Approved'; await Promise.all([loadLibrary(), loadTvState(), loadMovieState()]);
       }
       function showSearchResult(programme) {
         const built = programmeCard(programme, false); const button = document.createElement('button');
@@ -287,7 +319,7 @@ function parentPage(secret: string): string {
         if (!response.ok) { document.querySelector('#error').textContent = result.error; return; }
         parentToken = result.parentToken; document.querySelector('#install').href = result.installUrl;
         document.querySelector('#manifest').textContent = result.manifestUrl;
-        form.hidden = true; document.querySelector('#result').hidden = false; await Promise.all([loadLibrary(), loadTvState()]);
+        form.hidden = true; document.querySelector('#result').hidden = false; await Promise.all([loadLibrary(), loadTvState(), loadMovieState()]);
       });
       document.querySelector('#regenerate-tv').addEventListener('click', async (event) => {
         const button = event.currentTarget; button.disabled = true;
@@ -295,6 +327,13 @@ function parentPage(secret: string): string {
         const result = await response.json(); button.disabled = false;
         document.querySelector('#library-status').textContent = response.ok ? result.message : result.error;
         if (response.ok) await loadTvState();
+      });
+      document.querySelector('#reset-movies').addEventListener('click', async (event) => {
+        const button = event.currentTarget; button.disabled = true;
+        const response = await fetch('/api/households/${secret}/movie-rotation/reset', {method: 'POST', headers: headers()});
+        const result = await response.json(); button.disabled = false;
+        document.querySelector('#movie-status').textContent = response.ok ? result.message : result.error;
+        if (response.ok) await loadMovieState();
       });
       document.querySelector('#undo-tv').addEventListener('click', async (event) => {
         const button = event.currentTarget; button.disabled = true;
@@ -427,6 +466,7 @@ export default {
         const title = await new CinemetaClient(env.CINEMETA_ORIGIN).title(input.type, input.imdbId);
         if (!title) return json({ error: "Programme was not found in Cinemeta." }, 404);
         const programme = await approveProgramme(env.DB, household.id, title, input.startingEpisodeId);
+        if (programme.type === "movie") await reconcileMovieChannel(env.DB, household.id, env.MOVIE_ROTATION_SEED);
         return json({ programme }, 201);
       } catch (error) {
         const message = error instanceof Error ? error.message : "";
@@ -471,12 +511,7 @@ export default {
         ]);
         await refreshTvChannelSchedule(env.DB, household.id, false, env.TV_SCHEDULE_SEED);
       } else {
-        await env.DB.batch([
-          env.DB.prepare("DELETE FROM movie_rotation WHERE household_id = ? AND programme_id = ?").bind(household.id, programme.id),
-          env.DB.prepare("DELETE FROM current_programmes WHERE household_id = ? AND programme_id = ?").bind(household.id, programme.id),
-          env.DB.prepare("DELETE FROM approved_programmes WHERE id = ? AND household_id = ?").bind(programme.id, household.id),
-        ]);
-        await reconcileMovieChannel(env.DB, household.id, env.MOVIE_ROTATION_SEED);
+        await removeApprovedMovie(env.DB, household.id, programme.id, env.MOVIE_ROTATION_SEED);
       }
       return json({ message: `${programme.content_type === "show" ? "Show" : "Movie"} removed from future Channel selections. Restart Stremio to refresh the Channel.` });
     }
@@ -488,6 +523,25 @@ export default {
         return json({ error: "Parent authentication is required." }, 401);
       }
       return json(await parentTvChannelState(env.DB, household.id, env.TV_SCHEDULE_SEED));
+    }
+
+    const movieStateMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/movie-state$/);
+    if (request.method === "GET" && movieStateMatch) {
+      const household = await findHousehold(env.DB, movieStateMatch[1]);
+      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household.id, env.CONFIG_SECRET))) {
+        return json({ error: "Parent authentication is required." }, 401);
+      }
+      return json(await parentMovieChannelState(env.DB, household.id, env.MOVIE_ROTATION_SEED));
+    }
+
+    const resetMoviesMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/movie-rotation\/reset$/);
+    if (request.method === "POST" && resetMoviesMatch) {
+      const household = await findHousehold(env.DB, resetMoviesMatch[1]);
+      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household.id, env.CONFIG_SECRET))) {
+        return json({ error: "Parent authentication is required." }, 401);
+      }
+      await resetMovieRotation(env.DB, household.id, env.MOVIE_ROTATION_SEED);
+      return json({ message: "Movie rotation reset without interrupting the Current Programme. Restart Stremio to refresh the Channel." });
     }
 
     const progressMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/library\/([A-Za-z0-9-]+)\/progress$/);

--- a/src/movie-channel.ts
+++ b/src/movie-channel.ts
@@ -1,5 +1,6 @@
 export const MOVIE_CHANNEL_ID = "kids-channels:movie";
 const SIGN_OFF_PREFIX = `${MOVIE_CHANNEL_ID}:sign-off`;
+const MUTATION_ATTEMPTS = 5;
 
 interface MovieRow {
   programme_id: string;
@@ -16,6 +17,11 @@ interface MovieStateRow {
   cycle: number;
   current_position: number;
   selection_seed: string;
+  revision: number;
+}
+
+interface RotationRow extends MovieRow {
+  position: number;
 }
 
 interface CurrentMovieRow extends MovieRow, MovieStateRow {}
@@ -32,6 +38,19 @@ export interface MovieProgramme {
   cycle: number;
   position: number;
   signOffId: string;
+}
+
+export interface MoviePlaybackHistoryItem {
+  programmeId: string;
+  imdbId: string;
+  title: string;
+  playedAt: string;
+}
+
+export interface ParentMovieChannelState {
+  current?: MovieProgramme;
+  remaining: MovieProgramme[];
+  recentPlayback: MoviePlaybackHistoryItem[];
 }
 
 function stableIndex(seed: string, cycle: number, position: number, count: number): number {
@@ -61,7 +80,14 @@ async function approvedMovies(db: D1Database, householdId: string): Promise<Movi
   return rows.results;
 }
 
-function programmeFromRow(row: CurrentMovieRow): MovieProgramme {
+async function state(db: D1Database, householdId: string): Promise<MovieStateRow | null> {
+  return db.prepare(`SELECT cycle, current_position, selection_seed, revision
+    FROM movie_channel_state WHERE household_id = ?`).bind(householdId).first<MovieStateRow>();
+}
+
+function programmeFromRow(row: CurrentMovieRow | RotationRow, requestedCycle?: number): MovieProgramme {
+  const cycle = requestedCycle ?? ("cycle" in row ? row.cycle : 0);
+  const position = "position" in row ? row.position : row.current_position;
   return {
     programmeId: row.programme_id,
     imdbId: row.imdb_id,
@@ -71,14 +97,31 @@ function programmeFromRow(row: CurrentMovieRow): MovieProgramme {
     background: row.background ?? undefined,
     releaseInfo: row.release_info ?? undefined,
     approvedAt: row.approved_at,
-    cycle: row.cycle,
-    position: row.current_position,
-    signOffId: `${SIGN_OFF_PREFIX}:${row.cycle}:${row.current_position}`,
+    cycle,
+    position,
+    signOffId: `${SIGN_OFF_PREFIX}:${cycle}:${position}`,
   };
 }
 
+function mutationOwnership(householdId: string, revision: number, owner: string) {
+  const sql = `EXISTS (SELECT 1 FROM movie_channel_mutations mutation
+    WHERE mutation.household_id = ? AND mutation.revision = ? AND mutation.owner_token = ?)`;
+  return { sql, values: [householdId, revision, owner] as const };
+}
+
+function claimMutation(db: D1Database, householdId: string, revision: number, owner: string, now: string) {
+  return db.prepare(`INSERT OR IGNORE INTO movie_channel_mutations
+    (household_id, revision, owner_token, claimed_at) VALUES (?, ?, ?, ?)`)
+    .bind(householdId, revision, owner, now);
+}
+
+async function ownsMutation(db: D1Database, householdId: string, revision: number, owner: string): Promise<boolean> {
+  return Boolean(await db.prepare(`SELECT 1 FROM movie_channel_mutations
+    WHERE household_id = ? AND revision = ? AND owner_token = ?`).bind(householdId, revision, owner).first());
+}
+
 async function initialize(db: D1Database, householdId: string, configuredSeed?: string): Promise<void> {
-  if (await db.prepare("SELECT 1 FROM movie_channel_state WHERE household_id = ?").bind(householdId).first()) return;
+  if (await state(db, householdId)) return;
   const movies = await approvedMovies(db, householdId);
   if (movies.length === 0) return;
 
@@ -86,46 +129,29 @@ async function initialize(db: D1Database, householdId: string, configuredSeed?: 
   const rotation = shuffled(movies, seed, 0);
   const now = new Date().toISOString();
   const first = rotation[0];
+  const ownsInitialState = `EXISTS (SELECT 1 FROM movie_channel_state
+    WHERE household_id = ? AND selection_seed = ? AND revision = 0)`;
+  const initialOwnership = [householdId, seed] as const;
   const statements: D1PreparedStatement[] = [
     db.prepare(`INSERT OR IGNORE INTO movie_channel_state
-      (household_id, cycle, current_position, selection_seed, initialized_at)
-      VALUES (?, 0, 0, ?, ?)`).bind(householdId, seed, now),
+      (household_id, cycle, current_position, selection_seed, initialized_at, revision)
+      VALUES (?, 0, 0, ?, ?, 0)`).bind(householdId, seed, now),
   ];
   for (const [position, movie] of rotation.entries()) {
     statements.push(db.prepare(`INSERT OR IGNORE INTO movie_rotation
-      (household_id, cycle, position, programme_id) VALUES (?, 0, ?, ?)`)
-      .bind(householdId, position, movie.programme_id));
+      (household_id, cycle, position, programme_id)
+      SELECT ?, 0, ?, ? WHERE ${ownsInitialState}`)
+      .bind(householdId, position, movie.programme_id, ...initialOwnership));
   }
   statements.push(db.prepare(`INSERT OR IGNORE INTO current_programmes
     (household_id, channel, programme_id, video_id, selected_at)
-    VALUES (?, 'movie', ?, ?, ?)`).bind(householdId, first.programme_id, first.imdb_id, now));
+    SELECT ?, 'movie', ?, ?, ? WHERE ${ownsInitialState}`)
+    .bind(householdId, first.programme_id, first.imdb_id, now, ...initialOwnership));
   await db.batch(statements);
 }
 
-async function synchronizeRotation(db: D1Database, householdId: string): Promise<void> {
-  const state = await db.prepare(`SELECT cycle, current_position, selection_seed
-    FROM movie_channel_state WHERE household_id = ?`).bind(householdId).first<MovieStateRow>();
-  if (!state) return;
-  const missing = await db.prepare(`SELECT programme.id AS programme_id, programme.imdb_id,
-      programme.title, programme.description, programme.poster, programme.background,
-      programme.release_info, programme.approved_at
-    FROM approved_programmes programme
-    LEFT JOIN movie_rotation rotation ON rotation.household_id = programme.household_id
-      AND rotation.cycle = ? AND rotation.programme_id = programme.id
-    WHERE programme.household_id = ? AND programme.content_type = 'movie'
-      AND rotation.programme_id IS NULL
-    ORDER BY programme.approved_at, programme.id`).bind(state.cycle, householdId).all<MovieRow>();
-  if (missing.results.length === 0) return;
-  const maximum = await db.prepare(`SELECT COALESCE(MAX(position), -1) AS position FROM movie_rotation
-    WHERE household_id = ? AND cycle = ?`).bind(householdId, state.cycle).first<number>("position");
-  const additions = shuffled(missing.results, state.selection_seed, state.cycle);
-  await db.batch(additions.map((movie, offset) => db.prepare(`INSERT OR IGNORE INTO movie_rotation
-    (household_id, cycle, position, programme_id) VALUES (?, ?, ?, ?)`)
-    .bind(householdId, state.cycle, (maximum ?? -1) + offset + 1, movie.programme_id)));
-}
-
 async function current(db: D1Database, householdId: string): Promise<MovieProgramme | null> {
-  const row = await db.prepare(`SELECT state.cycle, state.current_position, state.selection_seed,
+  const row = await db.prepare(`SELECT state.cycle, state.current_position, state.selection_seed, state.revision,
       programme.id AS programme_id, programme.imdb_id, programme.title, programme.description,
       programme.poster, programme.background, programme.release_info, programme.approved_at
     FROM movie_channel_state state
@@ -137,6 +163,120 @@ async function current(db: D1Database, householdId: string): Promise<MovieProgra
   return row ? programmeFromRow(row) : null;
 }
 
+async function remainingRows(db: D1Database, householdId: string, currentState: MovieStateRow): Promise<RotationRow[]> {
+  const rows = await db.prepare(`SELECT rotation.position, programme.id AS programme_id, programme.imdb_id,
+      programme.title, programme.description, programme.poster, programme.background,
+      programme.release_info, programme.approved_at
+    FROM movie_rotation rotation
+    JOIN approved_programmes programme ON programme.id = rotation.programme_id
+    WHERE rotation.household_id = ? AND rotation.cycle = ? AND rotation.position > ?
+      AND rotation.consumed_at IS NULL AND programme.content_type = 'movie'
+    ORDER BY rotation.position`).bind(householdId, currentState.cycle, currentState.current_position).all<RotationRow>();
+  return rows.results;
+}
+
+async function synchronizeRotation(db: D1Database, householdId: string): Promise<void> {
+  for (let attempt = 0; attempt < MUTATION_ATTEMPTS; attempt += 1) {
+    const currentState = await state(db, householdId);
+    if (!currentState) return;
+    const [movies, existing, membership] = await Promise.all([
+      approvedMovies(db, householdId),
+      remainingRows(db, householdId, currentState),
+      db.prepare(`SELECT programme_id FROM movie_rotation WHERE household_id = ? AND cycle = ?`)
+        .bind(householdId, currentState.cycle).all<{ programme_id: string }>(),
+    ]);
+    const present = new Set(membership.results.map((movie) => movie.programme_id));
+    const additions = movies.filter((movie) => !present.has(movie.programme_id));
+    if (additions.length === 0) return;
+
+    const future: MovieRow[] = [...existing];
+    for (const movie of additions) {
+      const insertion = stableIndex(`${currentState.selection_seed}:${movie.programme_id}`,
+        currentState.cycle, currentState.revision, future.length + 1);
+      future.splice(insertion, 0, movie);
+    }
+    const owner = crypto.randomUUID();
+    const now = new Date().toISOString();
+    const owns = mutationOwnership(householdId, currentState.revision, owner);
+    const statements: D1PreparedStatement[] = [
+      claimMutation(db, householdId, currentState.revision, owner, now),
+      db.prepare(`DELETE FROM movie_rotation WHERE household_id = ? AND cycle = ? AND position > ? AND ${owns.sql}`)
+        .bind(householdId, currentState.cycle, currentState.current_position, ...owns.values),
+    ];
+    for (const [offset, movie] of future.entries()) {
+      statements.push(db.prepare(`INSERT INTO movie_rotation (household_id, cycle, position, programme_id)
+        SELECT ?, ?, ?, ? WHERE ${owns.sql}`)
+        .bind(householdId, currentState.cycle, currentState.current_position + offset + 1,
+          movie.programme_id, ...owns.values));
+    }
+    statements.push(db.prepare(`UPDATE movie_channel_state SET revision = revision + 1
+      WHERE household_id = ? AND cycle = ? AND current_position = ? AND revision = ? AND ${owns.sql}`)
+      .bind(householdId, currentState.cycle, currentState.current_position, currentState.revision, ...owns.values));
+    await db.batch(statements);
+    if (await ownsMutation(db, householdId, currentState.revision, owner)) return;
+  }
+}
+
+async function clearEmptyChannel(db: D1Database, householdId: string, currentState: MovieStateRow): Promise<void> {
+  const owner = crypto.randomUUID();
+  const now = new Date().toISOString();
+  const owns = mutationOwnership(householdId, currentState.revision, owner);
+  await db.batch([
+    claimMutation(db, householdId, currentState.revision, owner, now),
+    db.prepare(`DELETE FROM current_programmes WHERE household_id = ? AND channel = 'movie' AND ${owns.sql}`)
+      .bind(householdId, ...owns.values),
+    db.prepare(`DELETE FROM movie_advancements WHERE household_id = ? AND ${owns.sql}`).bind(householdId, ...owns.values),
+    db.prepare(`DELETE FROM movie_rotation WHERE household_id = ? AND ${owns.sql}`).bind(householdId, ...owns.values),
+    db.prepare(`DELETE FROM movie_channel_state WHERE household_id = ? AND revision = ? AND ${owns.sql}`)
+      .bind(householdId, currentState.revision, ...owns.values),
+  ]);
+}
+
+async function selectValidCurrent(db: D1Database, householdId: string): Promise<MovieProgramme | null> {
+  for (let attempt = 0; attempt < MUTATION_ATTEMPTS; attempt += 1) {
+    const currentProgramme = await current(db, householdId);
+    if (currentProgramme) return currentProgramme;
+    const currentState = await state(db, householdId);
+    if (!currentState) return null;
+    const movies = await approvedMovies(db, householdId);
+    if (movies.length === 0) {
+      await clearEmptyChannel(db, householdId, currentState);
+      return null;
+    }
+
+    const remaining = await remainingRows(db, householdId, currentState);
+    const nextCycle = remaining.length > 0 ? currentState.cycle : currentState.cycle + 1;
+    const nextPosition = remaining[0]?.position ?? 0;
+    const nextRotation = remaining.length > 0 ? [] : shuffled(movies, currentState.selection_seed, nextCycle);
+    const nextMovie = remaining[0] ?? nextRotation[0];
+    if (!nextMovie) return null;
+    const owner = crypto.randomUUID();
+    const now = new Date().toISOString();
+    const owns = mutationOwnership(householdId, currentState.revision, owner);
+    const statements: D1PreparedStatement[] = [claimMutation(db, householdId, currentState.revision, owner, now)];
+    for (const [position, movie] of nextRotation.entries()) {
+      statements.push(db.prepare(`INSERT OR IGNORE INTO movie_rotation
+        (household_id, cycle, position, programme_id)
+        SELECT ?, ?, ?, ? WHERE ${owns.sql}`)
+        .bind(householdId, nextCycle, position, movie.programme_id, ...owns.values));
+    }
+    statements.push(
+      db.prepare(`UPDATE movie_channel_state SET cycle = ?, current_position = ?, revision = revision + 1
+        WHERE household_id = ? AND cycle = ? AND current_position = ? AND revision = ? AND ${owns.sql}`)
+        .bind(nextCycle, nextPosition, householdId, currentState.cycle, currentState.current_position,
+          currentState.revision, ...owns.values),
+      db.prepare(`INSERT INTO current_programmes (household_id, channel, programme_id, video_id, selected_at)
+        SELECT ?, 'movie', ?, ?, ? WHERE ${owns.sql}
+        ON CONFLICT(household_id, channel) DO UPDATE SET programme_id = excluded.programme_id,
+          video_id = excluded.video_id, selected_at = excluded.selected_at`)
+        .bind(householdId, nextMovie.programme_id, nextMovie.imdb_id, now, ...owns.values),
+    );
+    await db.batch(statements);
+    if (await ownsMutation(db, householdId, currentState.revision, owner)) return current(db, householdId);
+  }
+  return current(db, householdId);
+}
+
 export async function reconcileMovieChannel(
   db: D1Database,
   householdId: string,
@@ -144,65 +284,7 @@ export async function reconcileMovieChannel(
 ): Promise<MovieProgramme | null> {
   await initialize(db, householdId, configuredSeed);
   await synchronizeRotation(db, householdId);
-  const state = await db.prepare(`SELECT cycle, current_position, selection_seed
-    FROM movie_channel_state WHERE household_id = ?`).bind(householdId).first<MovieStateRow>();
-  if (!state) return null;
-
-  const movies = await approvedMovies(db, householdId);
-  if (movies.length === 0) {
-    await db.batch([
-      db.prepare("DELETE FROM current_programmes WHERE household_id = ? AND channel = 'movie'").bind(householdId),
-      db.prepare("DELETE FROM movie_advancements WHERE household_id = ?").bind(householdId),
-      db.prepare("DELETE FROM movie_rotation WHERE household_id = ?").bind(householdId),
-      db.prepare("DELETE FROM movie_channel_state WHERE household_id = ?").bind(householdId),
-    ]);
-    return null;
-  }
-
-  const existing = await current(db, householdId);
-  if (existing) return existing;
-
-  const next = await db.prepare(`SELECT rotation.position, rotation.programme_id
-    FROM movie_rotation rotation
-    JOIN approved_programmes programme ON programme.id = rotation.programme_id
-    WHERE rotation.household_id = ? AND rotation.cycle = ? AND rotation.position > ?
-      AND rotation.consumed_at IS NULL AND programme.content_type = 'movie'
-    ORDER BY rotation.position LIMIT 1`).bind(householdId, state.cycle, state.current_position)
-    .first<{ position: number; programme_id: string }>();
-  const now = new Date().toISOString();
-  if (next) {
-    const nextMovie = movies.find((movie) => movie.programme_id === next.programme_id);
-    if (!nextMovie) return null;
-    await db.batch([
-      db.prepare("UPDATE movie_channel_state SET current_position = ? WHERE household_id = ?")
-        .bind(next.position, householdId),
-      db.prepare(`INSERT INTO current_programmes (household_id, channel, programme_id, video_id, selected_at)
-        VALUES (?, 'movie', ?, ?, ?)
-        ON CONFLICT(household_id, channel) DO UPDATE SET programme_id = excluded.programme_id,
-          video_id = excluded.video_id, selected_at = excluded.selected_at`)
-        .bind(householdId, nextMovie.programme_id, nextMovie.imdb_id, now),
-    ]);
-    return current(db, householdId);
-  }
-
-  const nextCycle = state.cycle + 1;
-  const rotation = shuffled(movies, state.selection_seed, nextCycle);
-  const statements: D1PreparedStatement[] = [
-    db.prepare("UPDATE movie_channel_state SET cycle = ?, current_position = 0 WHERE household_id = ?")
-      .bind(nextCycle, householdId),
-  ];
-  for (const [position, movie] of rotation.entries()) {
-    statements.push(db.prepare(`INSERT OR IGNORE INTO movie_rotation
-      (household_id, cycle, position, programme_id) VALUES (?, ?, ?, ?)`)
-      .bind(householdId, nextCycle, position, movie.programme_id));
-  }
-  statements.push(db.prepare(`INSERT INTO current_programmes
-    (household_id, channel, programme_id, video_id, selected_at) VALUES (?, 'movie', ?, ?, ?)
-    ON CONFLICT(household_id, channel) DO UPDATE SET programme_id = excluded.programme_id,
-      video_id = excluded.video_id, selected_at = excluded.selected_at`)
-    .bind(householdId, rotation[0].programme_id, rotation[0].imdb_id, now));
-  await db.batch(statements);
-  return current(db, householdId);
+  return selectValidCurrent(db, householdId);
 }
 
 export async function movieChannelProgramme(
@@ -211,6 +293,107 @@ export async function movieChannelProgramme(
   configuredSeed?: string,
 ): Promise<MovieProgramme | null> {
   return reconcileMovieChannel(db, householdId, configuredSeed);
+}
+
+export async function parentMovieChannelState(
+  db: D1Database,
+  householdId: string,
+  configuredSeed?: string,
+): Promise<ParentMovieChannelState> {
+  const currentProgramme = await reconcileMovieChannel(db, householdId, configuredSeed);
+  const currentState = await state(db, householdId);
+  const remaining = currentState ? await remainingRows(db, householdId, currentState) : [];
+  const history = await db.prepare(`SELECT programme_id, imdb_id, title, played_at
+    FROM movie_playback_history WHERE household_id = ? ORDER BY played_at DESC LIMIT 10`)
+    .bind(householdId).all<{ programme_id: string; imdb_id: string; title: string; played_at: string }>();
+  return {
+    current: currentProgramme ?? undefined,
+    remaining: remaining.map((movie) => programmeFromRow(movie, currentState!.cycle)),
+    recentPlayback: history.results.map((item) => ({
+      programmeId: item.programme_id,
+      imdbId: item.imdb_id,
+      title: item.title,
+      playedAt: item.played_at,
+    })),
+  };
+}
+
+export async function resetMovieRotation(
+  db: D1Database,
+  householdId: string,
+  configuredSeed?: string,
+): Promise<MovieProgramme | null> {
+  await reconcileMovieChannel(db, householdId, configuredSeed);
+  for (let attempt = 0; attempt < MUTATION_ATTEMPTS; attempt += 1) {
+    const currentState = await state(db, householdId);
+    const currentProgramme = await current(db, householdId);
+    if (!currentState || !currentProgramme) return currentProgramme;
+    const movies = await approvedMovies(db, householdId);
+    const seed = configuredSeed ? `${configuredSeed}:reset:${currentState.revision}` : crypto.randomUUID();
+    const future = shuffled(movies.filter((movie) => movie.programme_id !== currentProgramme.programmeId), seed, currentState.cycle);
+    const owner = crypto.randomUUID();
+    const now = new Date().toISOString();
+    const owns = mutationOwnership(householdId, currentState.revision, owner);
+    const statements: D1PreparedStatement[] = [
+      claimMutation(db, householdId, currentState.revision, owner, now),
+      db.prepare(`DELETE FROM movie_rotation WHERE household_id = ? AND cycle = ? AND position != ? AND ${owns.sql}`)
+        .bind(householdId, currentState.cycle, currentState.current_position, ...owns.values),
+      db.prepare(`UPDATE movie_rotation SET consumed_at = NULL WHERE household_id = ? AND cycle = ?
+        AND position = ? AND ${owns.sql}`)
+        .bind(householdId, currentState.cycle, currentState.current_position, ...owns.values),
+    ];
+    for (const [offset, movie] of future.entries()) {
+      statements.push(db.prepare(`INSERT INTO movie_rotation (household_id, cycle, position, programme_id)
+        SELECT ?, ?, ?, ? WHERE ${owns.sql}`)
+        .bind(householdId, currentState.cycle, currentState.current_position + offset + 1,
+          movie.programme_id, ...owns.values));
+    }
+    statements.push(db.prepare(`UPDATE movie_channel_state SET selection_seed = ?, revision = revision + 1
+      WHERE household_id = ? AND cycle = ? AND current_position = ? AND revision = ? AND ${owns.sql}`)
+      .bind(seed, householdId, currentState.cycle, currentState.current_position,
+        currentState.revision, ...owns.values));
+    await db.batch(statements);
+    if (await ownsMutation(db, householdId, currentState.revision, owner)) return current(db, householdId);
+  }
+  return current(db, householdId);
+}
+
+export async function removeApprovedMovie(
+  db: D1Database,
+  householdId: string,
+  programmeId: string,
+  configuredSeed?: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < MUTATION_ATTEMPTS; attempt += 1) {
+    const currentState = await state(db, householdId);
+    if (!currentState) {
+      await db.batch([
+        db.prepare("DELETE FROM current_programmes WHERE household_id = ? AND channel = 'movie' AND programme_id = ?")
+          .bind(householdId, programmeId),
+        db.prepare("DELETE FROM movie_rotation WHERE household_id = ? AND programme_id = ?").bind(householdId, programmeId),
+        db.prepare("DELETE FROM approved_programmes WHERE household_id = ? AND id = ? AND content_type = 'movie'")
+          .bind(householdId, programmeId),
+      ]);
+      return;
+    }
+    const owner = crypto.randomUUID();
+    const now = new Date().toISOString();
+    const owns = mutationOwnership(householdId, currentState.revision, owner);
+    await db.batch([
+      claimMutation(db, householdId, currentState.revision, owner, now),
+      db.prepare(`DELETE FROM current_programmes WHERE household_id = ? AND channel = 'movie'
+        AND programme_id = ? AND ${owns.sql}`).bind(householdId, programmeId, ...owns.values),
+      db.prepare(`DELETE FROM movie_rotation WHERE household_id = ? AND programme_id = ? AND ${owns.sql}`)
+        .bind(householdId, programmeId, ...owns.values),
+      db.prepare(`DELETE FROM approved_programmes WHERE household_id = ? AND id = ?
+        AND content_type = 'movie' AND ${owns.sql}`).bind(householdId, programmeId, ...owns.values),
+      db.prepare(`UPDATE movie_channel_state SET revision = revision + 1
+        WHERE household_id = ? AND revision = ? AND ${owns.sql}`)
+        .bind(householdId, currentState.revision, ...owns.values),
+    ]);
+    if (await ownsMutation(db, householdId, currentState.revision, owner)) break;
+  }
+  await reconcileMovieChannel(db, householdId, configuredSeed);
 }
 
 export function parseSignOffId(videoId: string): { cycle: number; position: number } | null {
@@ -225,52 +408,54 @@ export async function requestMovieSignOff(
   expectedCycle: number,
   expectedPosition: number,
 ): Promise<void> {
-  const state = await db.prepare(`SELECT cycle, current_position, selection_seed
-    FROM movie_channel_state WHERE household_id = ?`).bind(householdId).first<MovieStateRow>();
-  if (!state || state.cycle !== expectedCycle || state.current_position !== expectedPosition) return;
+  await reconcileMovieChannel(db, householdId);
+  for (let attempt = 0; attempt < MUTATION_ATTEMPTS; attempt += 1) {
+    const currentState = await state(db, householdId);
+    if (!currentState || currentState.cycle !== expectedCycle || currentState.current_position !== expectedPosition) return;
+    const currentProgramme = await current(db, householdId);
+    const movies = await approvedMovies(db, householdId);
+    if (!currentProgramme || movies.length === 0) return;
+    const remaining = await remainingRows(db, householdId, currentState);
+    const nextCycle = remaining.length > 0 ? currentState.cycle : currentState.cycle + 1;
+    const nextPosition = remaining[0]?.position ?? 0;
+    const nextRotation = remaining.length > 0 ? [] : shuffled(movies, currentState.selection_seed, nextCycle);
+    const nextMovie = remaining[0] ?? nextRotation[0];
+    if (!nextMovie) return;
 
-  const movies = await approvedMovies(db, householdId);
-  if (movies.length === 0) return;
-  const remaining = await db.prepare(`SELECT position FROM movie_rotation
-    WHERE household_id = ? AND cycle = ? AND position > ? AND consumed_at IS NULL
-    ORDER BY position LIMIT 1`).bind(householdId, state.cycle, state.current_position).first<{ position: number }>();
-  const nextCycle = remaining ? state.cycle : state.cycle + 1;
-  const nextPosition = remaining?.position ?? 0;
-  const nextRotation = remaining ? [] : shuffled(movies, state.selection_seed, nextCycle);
-  const nextProgrammeId = remaining
-    ? await db.prepare(`SELECT programme_id FROM movie_rotation
-        WHERE household_id = ? AND cycle = ? AND position = ?`)
-      .bind(householdId, nextCycle, nextPosition).first<string>("programme_id")
-    : nextRotation[0]?.programme_id;
-  const nextMovie = movies.find((movie) => movie.programme_id === nextProgrammeId);
-  if (!nextMovie) return;
-
-  const owner = crypto.randomUUID();
-  const now = new Date().toISOString();
-  const owns = `EXISTS (SELECT 1 FROM movie_advancements claim
-    WHERE claim.household_id = ? AND claim.cycle = ? AND claim.position = ? AND claim.owner_token = ?)`;
-  const ownership = [householdId, state.cycle, state.current_position, owner] as const;
-  const statements: D1PreparedStatement[] = [
-    db.prepare(`INSERT OR IGNORE INTO movie_advancements
-      (household_id, cycle, position, owner_token, advanced_at) VALUES (?, ?, ?, ?, ?)`)
-      .bind(householdId, state.cycle, state.current_position, owner, now),
-    db.prepare(`UPDATE movie_rotation SET consumed_at = ?
-      WHERE household_id = ? AND cycle = ? AND position = ? AND ${owns}`)
-      .bind(now, householdId, state.cycle, state.current_position, ...ownership),
-  ];
-  for (const [position, movie] of nextRotation.entries()) {
-    statements.push(db.prepare(`INSERT OR IGNORE INTO movie_rotation
-      (household_id, cycle, position, programme_id)
-      SELECT ?, ?, ?, ? WHERE ${owns}`)
-      .bind(householdId, nextCycle, position, movie.programme_id, ...ownership));
+    const owner = crypto.randomUUID();
+    const now = new Date().toISOString();
+    const owns = mutationOwnership(householdId, currentState.revision, owner);
+    const statements: D1PreparedStatement[] = [
+      claimMutation(db, householdId, currentState.revision, owner, now),
+      db.prepare(`INSERT OR IGNORE INTO movie_advancements
+        (household_id, cycle, position, owner_token, advanced_at)
+        SELECT ?, ?, ?, ?, ? WHERE ${owns.sql}`)
+        .bind(householdId, currentState.cycle, currentState.current_position, owner, now, ...owns.values),
+      db.prepare(`INSERT INTO movie_playback_history
+        (id, household_id, programme_id, imdb_id, title, cycle, position, played_at)
+        SELECT ?, ?, ?, ?, ?, ?, ?, ? WHERE ${owns.sql}`)
+        .bind(owner, householdId, currentProgramme.programmeId, currentProgramme.imdbId,
+          currentProgramme.title, currentState.cycle, currentState.current_position, now, ...owns.values),
+      db.prepare(`UPDATE movie_rotation SET consumed_at = ?
+        WHERE household_id = ? AND cycle = ? AND position = ? AND ${owns.sql}`)
+        .bind(now, householdId, currentState.cycle, currentState.current_position, ...owns.values),
+    ];
+    for (const [position, movie] of nextRotation.entries()) {
+      statements.push(db.prepare(`INSERT OR IGNORE INTO movie_rotation
+        (household_id, cycle, position, programme_id)
+        SELECT ?, ?, ?, ? WHERE ${owns.sql}`)
+        .bind(householdId, nextCycle, position, movie.programme_id, ...owns.values));
+    }
+    statements.push(
+      db.prepare(`UPDATE movie_channel_state SET cycle = ?, current_position = ?, revision = revision + 1
+        WHERE household_id = ? AND cycle = ? AND current_position = ? AND revision = ? AND ${owns.sql}`)
+        .bind(nextCycle, nextPosition, householdId, currentState.cycle, currentState.current_position,
+          currentState.revision, ...owns.values),
+      db.prepare(`UPDATE current_programmes SET programme_id = ?, video_id = ?, selected_at = ?
+        WHERE household_id = ? AND channel = 'movie' AND ${owns.sql}`)
+        .bind(nextMovie.programme_id, nextMovie.imdb_id, now, householdId, ...owns.values),
+    );
+    await db.batch(statements);
+    if (await ownsMutation(db, householdId, currentState.revision, owner)) return;
   }
-  statements.push(
-    db.prepare(`UPDATE movie_channel_state SET cycle = ?, current_position = ?
-      WHERE household_id = ? AND cycle = ? AND current_position = ? AND ${owns}`)
-      .bind(nextCycle, nextPosition, householdId, state.cycle, state.current_position, ...ownership),
-    db.prepare(`UPDATE current_programmes SET programme_id = ?, video_id = ?, selected_at = ?
-      WHERE household_id = ? AND channel = 'movie' AND ${owns}`)
-      .bind(nextMovie.programme_id, nextMovie.imdb_id, now, householdId, ...ownership),
-  );
-  await db.batch(statements);
 }

--- a/test/browser/approved-library.spec.ts
+++ b/test/browser/approved-library.spec.ts
@@ -64,6 +64,17 @@ test("a Parent searches Cinemeta and approves a movie and a show from another st
   const active = await channelMetadata();
   expect(active.tv.meta?.behaviorHints.defaultVideoId).toBe("tt1234567:1:2");
   expect(active.movie.meta?.behaviorHints.defaultVideoId).toBe("tt7654321");
+  await expect(page.locator("#movie-current")).toHaveText("Example: The Movie");
+  await expect(page.locator("#movie-rotation")).toHaveText("No movies remaining.");
+
+  await page.evaluate(async (base) => {
+    const metadata = await fetch(base + "/meta/movie/" + encodeURIComponent("kids-channels:movie") + ".json").then(response => response.json()) as any;
+    await fetch(metadata.meta.videos[1].streams[0].url);
+    await (globalThis as unknown as { loadMovieState(): Promise<void> }).loadMovieState();
+  }, addonBase);
+  await expect(page.locator("#movie-history")).toContainText("Example: The Movie");
+  await page.getByRole("button", { name: "Reset movie rotation" }).click();
+  await expect(page.locator("#movie-status")).toContainText("without interrupting the Current Programme");
 
   await approvedShow.getByRole("button", { name: "Pause show" }).click();
   await expect(page.locator("#library-status")).toContainText("Show paused");

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -58,7 +58,7 @@ beforeEach(async () => {
   )`).run();
   await env.DB.prepare(`CREATE TABLE IF NOT EXISTS movie_channel_state (
     household_id TEXT PRIMARY KEY NOT NULL, cycle INTEGER NOT NULL, current_position INTEGER NOT NULL,
-    selection_seed TEXT NOT NULL, initialized_at TEXT NOT NULL
+    selection_seed TEXT NOT NULL, initialized_at TEXT NOT NULL, revision INTEGER NOT NULL DEFAULT 0
   )`).run();
   await env.DB.prepare(`CREATE TABLE IF NOT EXISTS movie_rotation (
     household_id TEXT NOT NULL, cycle INTEGER NOT NULL, position INTEGER NOT NULL,
@@ -70,7 +70,18 @@ beforeEach(async () => {
     owner_token TEXT NOT NULL, advanced_at TEXT NOT NULL,
     PRIMARY KEY (household_id, cycle, position)
   )`).run();
+  await env.DB.prepare(`CREATE TABLE IF NOT EXISTS movie_channel_mutations (
+    household_id TEXT NOT NULL, revision INTEGER NOT NULL, owner_token TEXT NOT NULL, claimed_at TEXT NOT NULL,
+    PRIMARY KEY (household_id, revision)
+  )`).run();
+  await env.DB.prepare(`CREATE TABLE IF NOT EXISTS movie_playback_history (
+    id TEXT PRIMARY KEY NOT NULL, household_id TEXT NOT NULL, programme_id TEXT NOT NULL,
+    imdb_id TEXT NOT NULL, title TEXT NOT NULL, cycle INTEGER NOT NULL, position INTEGER NOT NULL,
+    played_at TEXT NOT NULL
+  )`).run();
   await env.DB.prepare("CREATE INDEX IF NOT EXISTS households_secret_idx ON households (secret)").run();
+  await env.DB.prepare("DELETE FROM movie_playback_history").run();
+  await env.DB.prepare("DELETE FROM movie_channel_mutations").run();
   await env.DB.prepare("DELETE FROM movie_advancements").run();
   await env.DB.prepare("DELETE FROM movie_rotation").run();
   await env.DB.prepare("DELETE FROM movie_channel_state").run();
@@ -646,6 +657,14 @@ describe("Movie Channel rotation and sign-off", () => {
     return (await SELF.fetch(`${base}/meta/movie/${encodeURIComponent("kids-channels:movie")}.json`)).json<any>();
   }
 
+  async function parentHeaders(created: CreatedHousehold) {
+    const response = await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/unlock`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ pin: "123456" }),
+    });
+    const { parentToken } = await response.json<{ parentToken: string }>();
+    return { authorization: `Bearer ${parentToken}` };
+  }
+
   it("keeps an interrupted canonical movie current and delegates its streams and subtitles to installed addons", async () => {
     const { base } = await arrangeMovies();
     const first = await metadata(base);
@@ -693,6 +712,15 @@ describe("Movie Channel rotation and sign-off", () => {
       (id, household_id, imdb_id, content_type, title, genres_json, approved_at)
       VALUES ('movie-3', ?, 'tt8000003', 'movie', 'Movie 3', '[]', ?)`).bind(created.householdId, now).run();
 
+    await Promise.all(Array.from({ length: 6 }, () => metadata(base)));
+    const insertedRotation = await env.DB.prepare(`SELECT COUNT(*) AS count,
+      COUNT(DISTINCT rotation.programme_id) AS distinct_count
+      FROM movie_rotation rotation JOIN movie_channel_state state
+        ON state.household_id = rotation.household_id AND state.cycle = rotation.cycle
+      WHERE rotation.household_id = ?`).bind(created.householdId)
+      .first<{ count: number; distinct_count: number }>();
+    expect(insertedRotation).toMatchObject({ count: 3, distinct_count: 3 });
+
     const selected: string[] = [];
     for (let index = 0; index < 3; index += 1) {
       const current = index === 0 ? first : await metadata(base);
@@ -700,6 +728,84 @@ describe("Movie Channel rotation and sign-off", () => {
       await SELF.fetch(current.meta.videos[1].streams[0].url);
     }
     expect(new Set(selected)).toEqual(new Set(["tt8000001", "tt8000002", "tt8000003"]));
+  });
+
+  it("shows the Current Programme, remaining rotation, and snapshot history only to the Parent", async () => {
+    const { created, base } = await arrangeMovies();
+    expect((await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/movie-state`)).status).toBe(401);
+    const before = await metadata(base);
+    const playedTitle = before.meta.videos[0].title;
+    await SELF.fetch(before.meta.videos[1].streams[0].url);
+
+    const response = await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/movie-state`, {
+      headers: await parentHeaders(created),
+    });
+    const channelState = await response.json<any>();
+    expect(response.status).toBe(200);
+    expect(channelState.current.title).not.toBe(playedTitle);
+    expect(channelState.remaining).toHaveLength(1);
+    expect(channelState.recentPlayback[0]).toMatchObject({ title: playedTitle, imdbId: expect.stringMatching(/^tt/) });
+    expect(JSON.stringify(channelState)).not.toContain(secretFrom(created));
+
+    const removal = await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/library/${channelState.recentPlayback[0].programmeId}`, {
+      method: "DELETE", headers: await parentHeaders(created),
+    });
+    expect(removal.status).toBe(200);
+    const afterRemoval = await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/movie-state`, {
+      headers: await parentHeaders(created),
+    }).then((result) => result.json<any>());
+    expect(afterRemoval.recentPlayback[0].title).toBe(playedTitle);
+  });
+
+  it("resets every approved movie exactly once without changing the active programme or sign-off", async () => {
+    const { created, base } = await arrangeMovies();
+    const first = await metadata(base);
+    await SELF.fetch(first.meta.videos[1].streams[0].url);
+    const active = await metadata(base);
+    const activeId = active.meta.behaviorHints.defaultVideoId;
+    const activeSignOff = active.meta.videos[1].streams[0].url;
+    const headers = await parentHeaders(created);
+
+    const response = await SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/movie-rotation/reset`, {
+      method: "POST", headers,
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ message: expect.stringContaining("without interrupting") });
+    const after = await metadata(base);
+    expect(after.meta.behaviorHints.defaultVideoId).toBe(activeId);
+    expect(after.meta.videos[1].streams[0].url).toBe(activeSignOff);
+
+    const rotation = await env.DB.prepare(`SELECT rotation.programme_id, rotation.consumed_at
+      FROM movie_rotation rotation JOIN movie_channel_state state
+        ON state.household_id = rotation.household_id AND state.cycle = rotation.cycle
+      WHERE rotation.household_id = ? ORDER BY rotation.position`).bind(created.householdId)
+      .all<{ programme_id: string; consumed_at: string | null }>();
+    expect(rotation.results).toHaveLength(3);
+    expect(new Set(rotation.results.map((item) => item.programme_id)).size).toBe(3);
+    expect(rotation.results.every((item) => item.consumed_at === null)).toBe(true);
+  });
+
+  it("serializes a Parent reset with playback advancement without consuming or duplicating a movie", async () => {
+    const { created, base } = await arrangeMovies();
+    const before = await metadata(base);
+    const headers = await parentHeaders(created);
+    const [signOff, reset] = await Promise.all([
+      SELF.fetch(before.meta.videos[1].streams[0].url),
+      SELF.fetch(`https://kids.test/api/households/${secretFrom(created)}/movie-rotation/reset`, { method: "POST", headers }),
+    ]);
+    expect(signOff.status).toBe(200);
+    expect(reset.status).toBe(200);
+
+    const after = await metadata(base);
+    expect(after.meta.behaviorHints.defaultVideoId).not.toBe(before.meta.behaviorHints.defaultVideoId);
+    const activeRotation = await env.DB.prepare(`SELECT rotation.programme_id
+      FROM movie_rotation rotation JOIN movie_channel_state state
+        ON state.household_id = rotation.household_id AND state.cycle = rotation.cycle
+      WHERE rotation.household_id = ?`).bind(created.householdId).all<{ programme_id: string }>();
+    expect(activeRotation.results).toHaveLength(3);
+    expect(new Set(activeRotation.results.map((item) => item.programme_id)).size).toBe(3);
+    expect(await env.DB.prepare("SELECT COUNT(*) AS count FROM movie_playback_history WHERE household_id = ?")
+      .bind(created.householdId).first()).toMatchObject({ count: 1 });
   });
 
   it("advances a shared rotation only once under concurrent sign-off requests and leaves sign-off final", async () => {


### PR DESCRIPTION
## Summary

- expose the Movie Channel Current Programme, remaining rotation, and recent playback on the Parent Page
- insert newly approved movies into the remaining shuffled rotation and add an intentional reset that preserves active playback
- serialize movie approval, removal, reset, and playback advancement with optimistic D1 mutation claims
- preserve snapshot playback history after Approved Library removal
- cover state, insertion uniqueness, reset, removal interaction, and concurrent Parent/playback actions in Worker and browser tests

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm test:browser`

Closes #14
