### PR TITLE
Complete Parent access and Household lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Keep `.dev.vars` private; `CONFIG_SECRET` signs one-hour Parent sessions. Open `
 
 Stremio retains loaded addon metadata in memory even when responses use `Cache-Control: no-store`. After a Parent changes the Approved Library or regenerates selections, fully close and reopen Stremio to load the updated Channel. The Worker state changes immediately and does not interrupt media already playing.
 
-Local D1 data is stored by Wrangler under `.wrangler/`. There is no forgotten-PIN recovery.
+Local D1 data is stored by Wrangler under `.wrangler/`. There is no forgotten-PIN or account recovery. Five incorrect PIN attempts from one request origin within 15 minutes lock PIN access from that origin for 15 minutes for that Household only. A Parent can rotate the PIN by supplying the current PIN; rotation invalidates older Parent sessions. Permanent deletion requires the current PIN plus the exact confirmation `DELETE`, removes all Household data, and invalidates every synced addon route.
 
 ## Test
 
@@ -35,7 +35,7 @@ pnpm test:browser
 # Or run both suites with: pnpm test:all
 ```
 
-The integration and protocol suite runs Household creation, PIN unlock, Cinemeta search, approval, deterministic rolling scheduling, shuffled movie rotation, concurrent advancement, sign-off delivery, and canonical programme metadata inside the Cloudflare Worker runtime against an isolated test D1 database. Cinemeta is stubbed only at outbound `fetch`. The Playwright suite starts a local Worker, local D1 database, and network-boundary Cinemeta stub to exercise the Parent Page in Chromium. Set `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` to use an existing Chromium binary instead of downloading one.
+The integration and protocol suite runs Household creation, isolated PIN rate limiting, PIN rotation and session invalidation, complete deletion, Cinemeta search, approval, deterministic rolling scheduling, shuffled movie rotation, concurrent advancement, sign-off delivery, and canonical programme metadata inside the Cloudflare Worker runtime against an isolated test D1 database. Cinemeta is stubbed only at outbound `fetch`. The Playwright suite starts a local Worker, local D1 database, and network-boundary Cinemeta stub to exercise the Parent Page in Chromium. Set `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` to use an existing Chromium binary instead of downloading one.
 
 Manual protocol-gate results are recorded in [`docs/first-playback-feasibility.md`](docs/first-playback-feasibility.md) and [`docs/continuous-tv-feasibility.md`](docs/continuous-tv-feasibility.md).
 
@@ -62,7 +62,9 @@ The Worker never receives stream-provider or Real-Debrid credentials. Household 
 - `GET /` — minimal Household creation Parent Page
 - `POST /api/households` — create a Household with a six-digit PIN
 - `GET /households/:secret` — PIN unlock Parent Page
-- `POST /api/households/:secret/unlock` — authenticate a Parent for one hour
+- `POST /api/households/:secret/unlock` — authenticate a Parent for one hour (rate-limited by Household and request origin)
+- `PUT /api/households/:secret/pin` — change the PIN after supplying the current PIN and invalidate older Parent sessions
+- `DELETE /api/households/:secret` — permanently delete the Household after current-PIN and exact `DELETE` confirmation
 - `GET /api/households/:secret/cinemeta/search?q=…` — search Cinemeta shows and movies (Parent bearer token required)
 - `GET /api/households/:secret/cinemeta/title/:type/:imdbId` — retrieve canonical title and released episode metadata (Parent bearer token required)
 - `GET|POST /api/households/:secret/library` — view or add to the Approved Library (Parent bearer token required)

--- a/migrations/0012_add_household_security_lifecycle.sql
+++ b/migrations/0012_add_household_security_lifecycle.sql
@@ -1,0 +1,11 @@
+ALTER TABLE households ADD COLUMN auth_version INTEGER NOT NULL DEFAULT 1;
+
+CREATE TABLE pin_attempts (
+  household_id TEXT NOT NULL,
+  origin_hash TEXT NOT NULL,
+  failed_attempts INTEGER NOT NULL,
+  window_started_at INTEGER NOT NULL,
+  blocked_until INTEGER,
+  PRIMARY KEY (household_id, origin_hash),
+  FOREIGN KEY (household_id) REFERENCES households(id) ON DELETE CASCADE
+);

--- a/src/households.ts
+++ b/src/households.ts
@@ -2,10 +2,18 @@ export interface Household {
   id: string;
   secret: string;
   created_at: string;
+  auth_version: number;
 }
+
+export type PinAuthentication =
+  | { status: "valid"; household: Household }
+  | { status: "invalid" }
+  | { status: "rate_limited"; retryAfter: number };
 
 const encoder = new TextEncoder();
 const PIN_ITERATIONS = 100_000;
+export const PIN_FAILURE_LIMIT = 5;
+export const PIN_RATE_LIMIT_SECONDS = 15 * 60;
 
 function randomBase64Url(byteLength: number): string {
   const bytes = crypto.getRandomValues(new Uint8Array(byteLength));
@@ -19,6 +27,13 @@ function bytesToBase64(bytes: ArrayBuffer | Uint8Array): string {
   let binary = "";
   for (const byte of view) binary += String.fromCharCode(byte);
   return btoa(binary);
+}
+
+function base64ToBytes(value: string): Uint8Array<ArrayBuffer> {
+  const decoded = atob(value);
+  const bytes = new Uint8Array(decoded.length);
+  for (let index = 0; index < decoded.length; index += 1) bytes[index] = decoded.charCodeAt(index);
+  return bytes;
 }
 
 async function derivePin(pin: string, salt: Uint8Array<ArrayBuffer>): Promise<string> {
@@ -40,6 +55,10 @@ function constantTimeEqual(left: string, right: string): boolean {
   return difference === 0;
 }
 
+async function hashOrigin(origin: string): Promise<string> {
+  return bytesToBase64(await crypto.subtle.digest("SHA-256", encoder.encode(origin)));
+}
+
 export function validPin(pin: unknown): pin is string {
   return typeof pin === "string" && /^\d{6}$/.test(pin);
 }
@@ -53,32 +72,105 @@ export async function createHousehold(db: D1Database, pin: string): Promise<Hous
 
   await db
     .prepare(
-      "INSERT INTO households (id, secret, pin_salt, pin_hash, created_at) VALUES (?, ?, ?, ?, ?)",
+      "INSERT INTO households (id, secret, pin_salt, pin_hash, created_at, auth_version) VALUES (?, ?, ?, ?, ?, 1)",
     )
     .bind(id, secret, bytesToBase64(salt), pinHash, createdAt)
     .run();
 
-  return { id, secret, created_at: createdAt };
+  return { id, secret, created_at: createdAt, auth_version: 1 };
 }
 
 export async function findHousehold(db: D1Database, secret: string): Promise<Household | null> {
   return db
-    .prepare("SELECT id, secret, created_at FROM households WHERE secret = ?")
+    .prepare("SELECT id, secret, created_at, auth_version FROM households WHERE secret = ?")
     .bind(secret)
     .first<Household>();
 }
 
-export async function verifyPin(db: D1Database, secret: string, pin: string): Promise<boolean> {
+export async function authenticatePin(
+  db: D1Database,
+  secret: string,
+  pin: string,
+  origin: string,
+  now = Date.now(),
+): Promise<PinAuthentication> {
   const record = await db
-    .prepare("SELECT pin_salt, pin_hash FROM households WHERE secret = ?")
+    .prepare("SELECT id, secret, pin_salt, pin_hash, created_at, auth_version FROM households WHERE secret = ?")
     .bind(secret)
-    .first<{ pin_salt: string; pin_hash: string }>();
+    .first<Household & { pin_salt: string; pin_hash: string }>();
+  if (!record) return { status: "invalid" };
 
-  if (!record) return false;
+  const originHash = await hashOrigin(origin);
+  const nowSeconds = Math.floor(now / 1000);
+  const attempt = await db.prepare(`SELECT blocked_until FROM pin_attempts
+    WHERE household_id = ? AND origin_hash = ?`).bind(record.id, originHash).first<{ blocked_until: number | null }>();
+  if (attempt?.blocked_until && attempt.blocked_until > nowSeconds) {
+    return { status: "rate_limited", retryAfter: attempt.blocked_until - nowSeconds };
+  }
 
-  const decodedSalt = atob(record.pin_salt);
-  const salt = new Uint8Array(decodedSalt.length);
-  for (let index = 0; index < decodedSalt.length; index += 1) salt[index] = decodedSalt.charCodeAt(index);
-  const suppliedHash = await derivePin(pin, salt);
-  return constantTimeEqual(record.pin_hash, suppliedHash);
+  const suppliedHash = await derivePin(pin, base64ToBytes(record.pin_salt));
+  if (constantTimeEqual(record.pin_hash, suppliedHash)) {
+    await db.prepare("DELETE FROM pin_attempts WHERE household_id = ? AND origin_hash = ?")
+      .bind(record.id, originHash).run();
+    return {
+      status: "valid",
+      household: { id: record.id, secret: record.secret, created_at: record.created_at, auth_version: record.auth_version },
+    };
+  }
+
+  const windowStartBoundary = nowSeconds - PIN_RATE_LIMIT_SECONDS;
+  await db.prepare(`INSERT INTO pin_attempts
+      (household_id, origin_hash, failed_attempts, window_started_at, blocked_until)
+    VALUES (?, ?, 1, ?, NULL)
+    ON CONFLICT (household_id, origin_hash) DO UPDATE SET
+      failed_attempts = CASE WHEN pin_attempts.window_started_at <= ? THEN 1 ELSE pin_attempts.failed_attempts + 1 END,
+      window_started_at = CASE WHEN pin_attempts.window_started_at <= ? THEN excluded.window_started_at ELSE pin_attempts.window_started_at END,
+      blocked_until = CASE
+        WHEN pin_attempts.window_started_at <= ? THEN NULL
+        WHEN pin_attempts.failed_attempts + 1 >= ? THEN ?
+        ELSE pin_attempts.blocked_until
+      END`)
+    .bind(record.id, originHash, nowSeconds, windowStartBoundary, windowStartBoundary, windowStartBoundary,
+      PIN_FAILURE_LIMIT, nowSeconds + PIN_RATE_LIMIT_SECONDS).run();
+  const updated = await db.prepare(`SELECT blocked_until FROM pin_attempts
+    WHERE household_id = ? AND origin_hash = ?`).bind(record.id, originHash).first<{ blocked_until: number | null }>();
+  if (updated?.blocked_until && updated.blocked_until > nowSeconds) {
+    return { status: "rate_limited", retryAfter: updated.blocked_until - nowSeconds };
+  }
+  return { status: "invalid" };
+}
+
+export async function rotatePin(db: D1Database, householdId: string, newPin: string): Promise<number> {
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const pinHash = await derivePin(newPin, salt);
+  await db.batch([
+    db.prepare(`UPDATE households SET pin_salt = ?, pin_hash = ?, auth_version = auth_version + 1
+      WHERE id = ?`).bind(bytesToBase64(salt), pinHash, householdId),
+    db.prepare("DELETE FROM pin_attempts WHERE household_id = ?").bind(householdId),
+  ]);
+  const household = await db.prepare("SELECT auth_version FROM households WHERE id = ?")
+    .bind(householdId).first<{ auth_version: number }>();
+  if (!household) throw new Error("household not found");
+  return household.auth_version;
+}
+
+export async function deleteHousehold(db: D1Database, householdId: string): Promise<void> {
+  const approved = "SELECT id FROM approved_programmes WHERE household_id = ?";
+  await db.batch([
+    db.prepare("DELETE FROM movie_playback_history WHERE household_id = ?").bind(householdId),
+    db.prepare("DELETE FROM movie_channel_mutations WHERE household_id = ?").bind(householdId),
+    db.prepare("DELETE FROM movie_advancements WHERE household_id = ?").bind(householdId),
+    db.prepare("DELETE FROM movie_rotation WHERE household_id = ?").bind(householdId),
+    db.prepare("DELETE FROM movie_channel_state WHERE household_id = ?").bind(householdId),
+    db.prepare("DELETE FROM tv_advancement_history WHERE household_id = ?").bind(householdId),
+    db.prepare("DELETE FROM channel_advancements WHERE household_id = ?").bind(householdId),
+    db.prepare("DELETE FROM channel_schedule WHERE household_id = ?").bind(householdId),
+    db.prepare("DELETE FROM channel_state WHERE household_id = ?").bind(householdId),
+    db.prepare("DELETE FROM current_programmes WHERE household_id = ?").bind(householdId),
+    db.prepare(`DELETE FROM show_progress WHERE programme_id IN (${approved})`).bind(householdId),
+    db.prepare(`DELETE FROM show_episodes WHERE programme_id IN (${approved})`).bind(householdId),
+    db.prepare("DELETE FROM approved_programmes WHERE household_id = ?").bind(householdId),
+    db.prepare("DELETE FROM pin_attempts WHERE household_id = ?").bind(householdId),
+    db.prepare("DELETE FROM households WHERE id = ?").bind(householdId),
+  ]);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,16 @@
 import { approveProgramme, approvedLibrary, hasApprovedProgramme } from "./approved-library";
 import { CinemetaClient, type ContentType } from "./cinemeta";
-import { createHousehold, findHousehold, validPin, verifyPin } from "./households";
+import {
+  authenticatePin,
+  createHousehold,
+  deleteHousehold,
+  findHousehold,
+  type Household,
+  PIN_FAILURE_LIMIT,
+  PIN_RATE_LIMIT_SECONDS,
+  rotatePin,
+  validPin,
+} from "./households";
 import {
   movieChannelProgramme,
   MOVIE_CHANNEL_ID,
@@ -72,6 +82,7 @@ function shell(content: string, title = "Kids Channels"): string {
     input[name="pin"] { letter-spacing: .2em; }
     button, .button { display: block; cursor: pointer; background: #725cff; border-color: #8c7aff; color: white; font-weight: 800; text-align: center; text-decoration: none; margin-top: 1rem; }
     .secondary { background: transparent; }
+    .danger { background: #a5263d; border-color: #e05a70; }
     .notice { border-left: .25rem solid #ffca5c; padding-left: 1rem; }
     .error { color: #ff9292; min-height: 1.5rem; }
     code { overflow-wrap: anywhere; color: #aeb8ff; }
@@ -140,6 +151,7 @@ function parentPage(secret: string): string {
   return shell(`
     <h1>Parent Page</h1>
     <p>Enter your six-digit PIN to manage this Household.</p>
+    <p class="notice">There is no forgotten-PIN or account recovery flow. ${PIN_FAILURE_LIMIT} incorrect attempts from the same origin within ${PIN_RATE_LIMIT_SECONDS / 60} minutes lock PIN access for ${PIN_RATE_LIMIT_SECONDS / 60} minutes for this Household only.</p>
     <form id="unlock-form">
       <label for="pin">Parent PIN</label>
       <input id="pin" name="pin" type="password" inputmode="numeric" pattern="[0-9]{6}" minlength="6" maxlength="6" autocomplete="current-password" required>
@@ -179,6 +191,26 @@ function parentPage(secret: string): string {
       <p id="library-status" role="status"></p>
       <div id="library"><p>No programmes approved yet.</p></div>
       <p class="notice">Install and configure a stream addon such as Comet in Stremio. Kids Channels selects the programme; Stremio resolves streams on your device.</p>
+      <h2>Parent access</h2>
+      <p class="notice">There is no forgotten-PIN or account recovery flow. Store the PIN somewhere safe.</p>
+      <form id="change-pin-form">
+        <label for="current-pin">Current PIN</label>
+        <input id="current-pin" name="currentPin" type="password" inputmode="numeric" pattern="[0-9]{6}" minlength="6" maxlength="6" autocomplete="current-password" required>
+        <label for="new-pin">New six-digit PIN</label>
+        <input id="new-pin" name="newPin" type="password" inputmode="numeric" pattern="[0-9]{6}" minlength="6" maxlength="6" autocomplete="new-password" required>
+        <button type="submit">Change Parent PIN</button>
+        <p id="pin-status" role="status"></p>
+      </form>
+      <h2>Delete Household</h2>
+      <p class="notice">Permanent deletion removes the Approved Library, Channel state, history, PIN, and synced addon access. This cannot be undone.</p>
+      <form id="delete-form">
+        <label for="delete-pin">Current PIN</label>
+        <input id="delete-pin" name="currentPin" type="password" inputmode="numeric" pattern="[0-9]{6}" minlength="6" maxlength="6" autocomplete="current-password" required>
+        <label for="delete-confirmation">Type DELETE to confirm</label>
+        <input id="delete-confirmation" name="confirmation" pattern="DELETE" autocomplete="off" required>
+        <button type="submit" class="danger">Permanently delete Household</button>
+        <p id="delete-status" class="error" role="alert"></p>
+      </form>
     </section>
     <script>
       const form = document.querySelector('#unlock-form');
@@ -351,6 +383,25 @@ function parentPage(secret: string): string {
         status.textContent = result.results.length ? result.results.length + ' results' : 'No matching shows or movies.';
         result.results.forEach(programme => output.append(showSearchResult(programme)));
       });
+      document.querySelector('#change-pin-form').addEventListener('submit', async (event) => {
+        event.preventDefault(); const data = new FormData(event.currentTarget); const status = document.querySelector('#pin-status');
+        const response = await fetch('/api/households/${secret}/pin', {
+          method: 'PUT', headers: {...headers(), 'content-type': 'application/json'},
+          body: JSON.stringify({currentPin: data.get('currentPin'), newPin: data.get('newPin')})
+        });
+        const result = await response.json(); status.textContent = response.ok ? result.message : result.error;
+        if (response.ok) { parentToken = result.parentToken; event.currentTarget.reset(); }
+      });
+      document.querySelector('#delete-form').addEventListener('submit', async (event) => {
+        event.preventDefault(); const data = new FormData(event.currentTarget); const status = document.querySelector('#delete-status');
+        const response = await fetch('/api/households/${secret}', {
+          method: 'DELETE', headers: {...headers(), 'content-type': 'application/json'},
+          body: JSON.stringify({currentPin: data.get('currentPin'), confirmation: data.get('confirmation')})
+        });
+        const result = await response.json();
+        if (!response.ok) { status.textContent = result.error; return; }
+        document.querySelector('main').innerHTML = '<h1>Household deleted</h1><p>All Household data and synced addon access have been permanently removed.</p>';
+      });
     </script>`);
 }
 
@@ -371,10 +422,22 @@ async function parsePin(request: Request): Promise<unknown> {
   }
 }
 
-async function authorizedParent(request: Request, householdId: string, deploymentSecret: string): Promise<boolean> {
+async function authorizedParent(request: Request, household: Household, deploymentSecret: string): Promise<boolean> {
   const authorization = request.headers.get("authorization");
   if (!authorization?.startsWith("Bearer ")) return false;
-  return verifyParentToken(authorization.slice(7), householdId, deploymentSecret);
+  return verifyParentToken(authorization.slice(7), household.id, household.auth_version, deploymentSecret);
+}
+
+function pinRequestOrigin(request: Request): string {
+  return request.headers.get("cf-connecting-ip") || "unknown-origin";
+}
+
+function rateLimitedPin(retryAfter: number): Response {
+  return json(
+    { error: `Too many incorrect PIN attempts. Try again in ${Math.ceil(retryAfter / 60)} minutes.` },
+    429,
+    { "retry-after": String(retryAfter), "cache-control": "no-store" },
+  );
 }
 
 function decodedPathSegment(value: string): string | null {
@@ -406,20 +469,59 @@ export default {
     if (request.method === "POST" && unlockMatch) {
       const pin = await parsePin(request);
       if (!validPin(pin)) return json({ error: "PIN must contain exactly six digits." }, 400);
-      if (!(await verifyPin(env.DB, unlockMatch[1], pin))) return json({ error: "Household or PIN is incorrect." }, 401);
-      const household = await findHousehold(env.DB, unlockMatch[1]);
-      if (!household) return json({ error: "Household or PIN is incorrect." }, 401);
-      if (!env.CONFIG_SECRET) return json({ error: "Provider configuration is unavailable." }, 503);
+      const authentication = await authenticatePin(env.DB, unlockMatch[1], pin, pinRequestOrigin(request));
+      if (authentication.status === "rate_limited") return rateLimitedPin(authentication.retryAfter);
+      if (authentication.status === "invalid") return json({ error: "Household or PIN is incorrect." }, 401);
+      if (!env.CONFIG_SECRET) return json({ error: "Parent access is temporarily unavailable." }, 503);
       return json({
         ...installDetails(url.origin, unlockMatch[1]),
-        parentToken: await issueParentToken(household.id, env.CONFIG_SECRET),
-      });
+        parentToken: await issueParentToken(authentication.household.id, authentication.household.auth_version, env.CONFIG_SECRET),
+      }, 200, { "cache-control": "no-store" });
+    }
+
+    const pinMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/pin$/);
+    if (request.method === "PUT" && pinMatch) {
+      const household = await findHousehold(env.DB, pinMatch[1]);
+      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household, env.CONFIG_SECRET))) {
+        return json({ error: "Parent authentication is required." }, 401);
+      }
+      let input: { currentPin?: unknown; newPin?: unknown } = {};
+      try { input = await request.json() as typeof input; } catch { /* handled below */ }
+      if (!validPin(input.currentPin) || !validPin(input.newPin)) {
+        return json({ error: "Current and new PINs must each contain exactly six digits." }, 400);
+      }
+      if (input.currentPin === input.newPin) return json({ error: "Choose a new PIN that differs from the current PIN." }, 400);
+      const authentication = await authenticatePin(env.DB, household.secret, input.currentPin, pinRequestOrigin(request));
+      if (authentication.status === "rate_limited") return rateLimitedPin(authentication.retryAfter);
+      if (authentication.status === "invalid") return json({ error: "Current PIN is incorrect." }, 401);
+      const authVersion = await rotatePin(env.DB, household.id, input.newPin);
+      return json({
+        message: "Parent PIN changed. Previous Parent sessions have been signed out.",
+        parentToken: await issueParentToken(household.id, authVersion, env.CONFIG_SECRET),
+      }, 200, { "cache-control": "no-store" });
+    }
+
+    const deleteMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)$/);
+    if (request.method === "DELETE" && deleteMatch) {
+      const household = await findHousehold(env.DB, deleteMatch[1]);
+      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household, env.CONFIG_SECRET))) {
+        return json({ error: "Parent authentication is required." }, 401);
+      }
+      let input: { currentPin?: unknown; confirmation?: unknown } = {};
+      try { input = await request.json() as typeof input; } catch { /* handled below */ }
+      if (input.confirmation !== "DELETE") return json({ error: "Type DELETE exactly to confirm permanent deletion." }, 400);
+      if (!validPin(input.currentPin)) return json({ error: "Enter the current six-digit PIN." }, 400);
+      const authentication = await authenticatePin(env.DB, household.secret, input.currentPin, pinRequestOrigin(request));
+      if (authentication.status === "rate_limited") return rateLimitedPin(authentication.retryAfter);
+      if (authentication.status === "invalid") return json({ error: "Current PIN is incorrect." }, 401);
+      await deleteHousehold(env.DB, household.id);
+      return json({ message: "Household permanently deleted." }, 200, { "cache-control": "no-store" });
     }
 
     const searchMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/cinemeta\/search$/);
     if (request.method === "GET" && searchMatch) {
       const household = await findHousehold(env.DB, searchMatch[1]);
-      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household.id, env.CONFIG_SECRET))) {
+      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household, env.CONFIG_SECRET))) {
         return json({ error: "Parent authentication is required." }, 401);
       }
       const query = url.searchParams.get("q")?.trim();
@@ -434,7 +536,7 @@ export default {
     const titleMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/cinemeta\/title\/(show|movie)\/(tt\d+)$/);
     if (request.method === "GET" && titleMatch) {
       const household = await findHousehold(env.DB, titleMatch[1]);
-      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household.id, env.CONFIG_SECRET))) {
+      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household, env.CONFIG_SECRET))) {
         return json({ error: "Parent authentication is required." }, 401);
       }
       try {
@@ -449,7 +551,7 @@ export default {
     const libraryMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/library$/);
     if (libraryMatch && (request.method === "GET" || request.method === "POST")) {
       const household = await findHousehold(env.DB, libraryMatch[1]);
-      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household.id, env.CONFIG_SECRET))) {
+      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household, env.CONFIG_SECRET))) {
         return json({ error: "Parent authentication is required." }, 401);
       }
       if (request.method === "GET") return json({ programmes: await approvedLibrary(env.DB, household.id) });
@@ -480,7 +582,7 @@ export default {
     const libraryProgrammeMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/library\/([A-Za-z0-9-]+)$/);
     if (libraryProgrammeMatch && (request.method === "PATCH" || request.method === "DELETE")) {
       const household = await findHousehold(env.DB, libraryProgrammeMatch[1]);
-      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household.id, env.CONFIG_SECRET))) {
+      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household, env.CONFIG_SECRET))) {
         return json({ error: "Parent authentication is required." }, 401);
       }
       const programme = await env.DB.prepare(`SELECT id, content_type FROM approved_programmes
@@ -519,7 +621,7 @@ export default {
     const tvStateMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/tv-state$/);
     if (request.method === "GET" && tvStateMatch) {
       const household = await findHousehold(env.DB, tvStateMatch[1]);
-      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household.id, env.CONFIG_SECRET))) {
+      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household, env.CONFIG_SECRET))) {
         return json({ error: "Parent authentication is required." }, 401);
       }
       return json(await parentTvChannelState(env.DB, household.id, env.TV_SCHEDULE_SEED));
@@ -528,7 +630,7 @@ export default {
     const movieStateMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/movie-state$/);
     if (request.method === "GET" && movieStateMatch) {
       const household = await findHousehold(env.DB, movieStateMatch[1]);
-      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household.id, env.CONFIG_SECRET))) {
+      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household, env.CONFIG_SECRET))) {
         return json({ error: "Parent authentication is required." }, 401);
       }
       return json(await parentMovieChannelState(env.DB, household.id, env.MOVIE_ROTATION_SEED));
@@ -537,7 +639,7 @@ export default {
     const resetMoviesMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/movie-rotation\/reset$/);
     if (request.method === "POST" && resetMoviesMatch) {
       const household = await findHousehold(env.DB, resetMoviesMatch[1]);
-      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household.id, env.CONFIG_SECRET))) {
+      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household, env.CONFIG_SECRET))) {
         return json({ error: "Parent authentication is required." }, 401);
       }
       await resetMovieRotation(env.DB, household.id, env.MOVIE_ROTATION_SEED);
@@ -547,7 +649,7 @@ export default {
     const progressMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/library\/([A-Za-z0-9-]+)\/progress$/);
     if (request.method === "PATCH" && progressMatch) {
       const household = await findHousehold(env.DB, progressMatch[1]);
-      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household.id, env.CONFIG_SECRET))) {
+      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household, env.CONFIG_SECRET))) {
         return json({ error: "Parent authentication is required." }, 401);
       }
       let input: { videoId?: unknown } = {};
@@ -567,7 +669,7 @@ export default {
     const undoMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/tv-schedule\/undo$/);
     if (request.method === "POST" && undoMatch) {
       const household = await findHousehold(env.DB, undoMatch[1]);
-      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household.id, env.CONFIG_SECRET))) {
+      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household, env.CONFIG_SECRET))) {
         return json({ error: "Parent authentication is required." }, 401);
       }
       const undone = await undoLatestTvAdvancement(env.DB, household.id, env.TV_SCHEDULE_SEED);
@@ -578,7 +680,7 @@ export default {
     const regenerateMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/tv-schedule\/regenerate$/);
     if (request.method === "POST" && regenerateMatch) {
       const household = await findHousehold(env.DB, regenerateMatch[1]);
-      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household.id, env.CONFIG_SECRET))) {
+      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household, env.CONFIG_SECRET))) {
         return json({ error: "Parent authentication is required." }, 401);
       }
       await refreshTvChannelSchedule(env.DB, household.id, true, env.TV_SCHEDULE_SEED);

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -21,22 +21,22 @@ async function keyMaterial(secret: string): Promise<ArrayBuffer> {
   return crypto.subtle.digest("SHA-256", encoder.encode(secret));
 }
 
-export async function issueParentToken(householdId: string, secret: string, now = Date.now()): Promise<string> {
-  const payload = toBase64Url(encoder.encode(JSON.stringify({ expiresAt: now + 60 * 60 * 1000 })));
+export async function issueParentToken(householdId: string, authVersion: number, secret: string, now = Date.now()): Promise<string> {
+  const payload = toBase64Url(encoder.encode(JSON.stringify({ expiresAt: now + 60 * 60 * 1000, authVersion })));
   const key = await crypto.subtle.importKey("raw", await keyMaterial(secret), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
   const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(`${householdId}.${payload}`));
   return `${payload}.${toBase64Url(signature)}`;
 }
 
-export async function verifyParentToken(token: string, householdId: string, secret: string, now = Date.now()): Promise<boolean> {
+export async function verifyParentToken(token: string, householdId: string, authVersion: number, secret: string, now = Date.now()): Promise<boolean> {
   try {
     const [payload, signature, extra] = token.split(".");
     if (!payload || !signature || extra) return false;
     const key = await crypto.subtle.importKey("raw", await keyMaterial(secret), { name: "HMAC", hash: "SHA-256" }, false, ["verify"]);
     const valid = await crypto.subtle.verify("HMAC", key, fromBase64Url(signature), encoder.encode(`${householdId}.${payload}`));
     if (!valid) return false;
-    const parsed = JSON.parse(decoder.decode(fromBase64Url(payload))) as { expiresAt?: unknown };
-    return typeof parsed.expiresAt === "number" && parsed.expiresAt > now;
+    const parsed = JSON.parse(decoder.decode(fromBase64Url(payload))) as { expiresAt?: unknown; authVersion?: unknown };
+    return typeof parsed.expiresAt === "number" && parsed.expiresAt > now && parsed.authVersion === authVersion;
   } catch {
     return false;
   }

--- a/test/browser/household-lifecycle.spec.ts
+++ b/test/browser/household-lifecycle.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test, type Page } from "@playwright/test";
+
+async function createHousehold(page: Page, pin: string) {
+  await page.goto("/");
+  await page.getByLabel("Choose a six-digit Parent PIN").fill(pin);
+  await page.getByRole("button", { name: "Create Household" }).click();
+  const parentUrl = await page.getByRole("link", { name: "Open Parent Page" }).getAttribute("href");
+  const manifestUrl = await page.locator("#manifest").textContent();
+  expect(parentUrl).toBeTruthy();
+  expect(manifestUrl).toBeTruthy();
+  return { parentUrl: parentUrl!, manifestUrl: manifestUrl! };
+}
+
+async function submitUnlock(page: Page, pin: string) {
+  await page.getByLabel("Parent PIN").fill(pin);
+  const responsePromise = page.waitForResponse(response => response.url().endsWith("/unlock"));
+  await page.getByRole("button", { name: "Unlock Household" }).click();
+  return responsePromise;
+}
+
+test("a Parent rotates the PIN, sees recovery limitations, and permanently deletes the Household", async ({ page }) => {
+  const household = await createHousehold(page, "123456");
+  await page.goto(household.parentUrl);
+  await expect(page.getByText("There is no forgotten-PIN or account recovery flow").first()).toBeVisible();
+  expect((await submitUnlock(page, "123456")).status()).toBe(200);
+  await expect(page.getByRole("heading", { name: "Parent access" })).toBeVisible();
+
+  await page.getByLabel("Current PIN", { exact: true }).first().fill("000000");
+  await page.getByLabel("New six-digit PIN").fill("654321");
+  await page.getByRole("button", { name: "Change Parent PIN" }).click();
+  await expect(page.locator("#pin-status")).toHaveText("Current PIN is incorrect.");
+
+  await page.getByLabel("Current PIN", { exact: true }).first().fill("123456");
+  await page.getByRole("button", { name: "Change Parent PIN" }).click();
+  await expect(page.locator("#pin-status")).toContainText("Previous Parent sessions have been signed out");
+
+  await page.getByLabel("Current PIN", { exact: true }).last().fill("654321");
+  await page.getByLabel("Type DELETE to confirm").fill("DELETE");
+  await page.getByRole("button", { name: "Permanently delete Household" }).click();
+  await expect(page.getByRole("heading", { name: "Household deleted" })).toBeVisible();
+
+  for (const route of [household.parentUrl, household.manifestUrl,
+    household.manifestUrl.replace("/manifest.json", "/catalog/series/kids-tv-channel.json")]) {
+    const response = await page.request.get(route);
+    expect(response.status()).toBe(404);
+    expect(await response.text()).not.toContain(new URL(household.manifestUrl).pathname.split("/")[2]);
+  }
+});
+
+test("browser PIN failures rate-limit only the targeted Household", async ({ page }) => {
+  const limitedHousehold = await createHousehold(page, "123456");
+  await page.goto(limitedHousehold.parentUrl);
+  let limitedResponse;
+  for (let attempt = 0; attempt < 5; attempt += 1) limitedResponse = await submitUnlock(page, "000000");
+  expect(limitedResponse!.status()).toBe(429);
+  expect(limitedResponse!.headers()["retry-after"]).toBe("900");
+  await expect(page.locator("#error")).toContainText("Too many incorrect PIN attempts");
+  expect(await limitedResponse!.text()).not.toContain(new URL(limitedHousehold.manifestUrl).pathname.split("/")[2]);
+
+  const otherHousehold = await createHousehold(page, "654321");
+  await page.goto(otherHousehold.parentUrl);
+  expect((await submitUnlock(page, "654321")).status()).toBe(200);
+  await expect(page.getByRole("heading", { name: "Approved Library" })).toBeVisible();
+});

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -14,7 +14,13 @@ beforeEach(async () => {
     secret TEXT UNIQUE NOT NULL,
     pin_salt TEXT NOT NULL,
     pin_hash TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    auth_version INTEGER NOT NULL DEFAULT 1
+  )`).run();
+  await env.DB.prepare(`CREATE TABLE IF NOT EXISTS pin_attempts (
+    household_id TEXT NOT NULL, origin_hash TEXT NOT NULL, failed_attempts INTEGER NOT NULL,
+    window_started_at INTEGER NOT NULL, blocked_until INTEGER,
+    PRIMARY KEY (household_id, origin_hash)
   )`).run();
   await env.DB.prepare(`CREATE TABLE IF NOT EXISTS approved_programmes (
     id TEXT PRIMARY KEY NOT NULL, household_id TEXT NOT NULL, imdb_id TEXT NOT NULL,
@@ -80,6 +86,7 @@ beforeEach(async () => {
     played_at TEXT NOT NULL
   )`).run();
   await env.DB.prepare("CREATE INDEX IF NOT EXISTS households_secret_idx ON households (secret)").run();
+  await env.DB.prepare("DELETE FROM pin_attempts").run();
   await env.DB.prepare("DELETE FROM movie_playback_history").run();
   await env.DB.prepare("DELETE FROM movie_channel_mutations").run();
   await env.DB.prepare("DELETE FROM movie_advancements").run();
@@ -172,6 +179,65 @@ describe("Parent Page Household creation", () => {
     });
     expect(unlocked.status).toBe(200);
     expect(await unlocked.json()).toMatchObject({ manifestUrl: created.manifestUrl });
+  });
+
+  it("rate-limits PIN failures by Household and request origin without exposing secrets", async () => {
+    const first = await create();
+    const second = await create("654321");
+    const unlock = (created: CreatedHousehold, pin: string, origin: string) => SELF.fetch(
+      `https://kids.test/api/households/${secretFrom(created)}/unlock`,
+      { method: "POST", headers: { "content-type": "application/json", "cf-connecting-ip": origin }, body: JSON.stringify({ pin }) },
+    );
+
+    for (let attempt = 1; attempt < 5; attempt += 1) {
+      expect((await unlock(first, "000000", "192.0.2.10")).status).toBe(401);
+    }
+    const limited = await unlock(first, "000000", "192.0.2.10");
+    expect(limited.status).toBe(429);
+    expect(limited.headers.get("retry-after")).toBe("900");
+    const limitedBody = await limited.text();
+    expect(limitedBody).not.toContain(secretFrom(first));
+    expect(limitedBody).not.toContain("000000");
+
+    expect((await unlock(first, "123456", "192.0.2.11")).status).toBe(200);
+    expect((await unlock(second, "654321", "192.0.2.10")).status).toBe(200);
+  });
+
+  it("rotates the PIN only with the current PIN and invalidates older Parent sessions", async () => {
+    const created = await create();
+    const secret = secretFrom(created);
+    const unlocked = await SELF.fetch(`https://kids.test/api/households/${secret}/unlock`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ pin: "123456" }),
+    });
+    const { parentToken } = await unlocked.json<{ parentToken: string }>();
+    const authorization = `Bearer ${parentToken}`;
+
+    const denied = await SELF.fetch(`https://kids.test/api/households/${secret}/pin`, {
+      method: "PUT", headers: { authorization, "content-type": "application/json" },
+      body: JSON.stringify({ currentPin: "000000", newPin: "654321" }),
+    });
+    expect(denied.status).toBe(401);
+
+    const rotated = await SELF.fetch(`https://kids.test/api/households/${secret}/pin`, {
+      method: "PUT", headers: { authorization, "content-type": "application/json" },
+      body: JSON.stringify({ currentPin: "123456", newPin: "654321" }),
+    });
+    expect(rotated.status).toBe(200);
+    const rotatedBody = await rotated.json<{ parentToken: string }>();
+    expect(rotatedBody.parentToken).not.toBe(parentToken);
+    expect((await SELF.fetch(`https://kids.test/api/households/${secret}/tv-state`, { headers: { authorization } })).status).toBe(401);
+    expect((await SELF.fetch(`https://kids.test/api/households/${secret}/tv-state`, {
+      headers: { authorization: `Bearer ${rotatedBody.parentToken}` },
+    })).status).toBe(200);
+
+    const oldPin = await SELF.fetch(`https://kids.test/api/households/${secret}/unlock`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ pin: "123456" }),
+    });
+    expect(oldPin.status).toBe(401);
+    const newPin = await SELF.fetch(`https://kids.test/api/households/${secret}/unlock`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ pin: "654321" }),
+    });
+    expect(newPin.status).toBe(200);
   });
 });
 
@@ -847,6 +913,71 @@ describe("Movie Channel rotation and sign-off", () => {
     const clamped = await SELF.fetch(url, { headers: { range: "bytes=100-999999" } });
     expect(clamped.status).toBe(206);
     expect(clamped.headers.get("content-range")).toBe(`bytes 100-${length - 1}/${length}`);
+  });
+});
+
+describe("Household deletion", () => {
+  it("requires explicit confirmation and current PIN, removes all state, and invalidates every synced route", async () => {
+    const created = await create();
+    const secret = secretFrom(created);
+    const unlock = await SELF.fetch(`https://kids.test/api/households/${secret}/unlock`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ pin: "123456" }),
+    });
+    const { parentToken } = await unlock.json<{ parentToken: string }>();
+    const headers = { authorization: `Bearer ${parentToken}`, "content-type": "application/json" };
+
+    const unconfirmed = await SELF.fetch(`https://kids.test/api/households/${secret}`, {
+      method: "DELETE", headers, body: JSON.stringify({ currentPin: "123456", confirmation: "delete" }),
+    });
+    expect(unconfirmed.status).toBe(400);
+    const wrongPin = await SELF.fetch(`https://kids.test/api/households/${secret}`, {
+      method: "DELETE", headers, body: JSON.stringify({ currentPin: "000000", confirmation: "DELETE" }),
+    });
+    expect(wrongPin.status).toBe(401);
+
+    const householdId = created.householdId;
+    await env.DB.prepare(`INSERT INTO approved_programmes
+      (id, household_id, imdb_id, content_type, title, genres_json, approved_at)
+      VALUES ('programme-delete', ?, 'tt1234567', 'show', 'Delete me', '[]', 'now')`).bind(householdId).run();
+    await env.DB.prepare("INSERT INTO show_episodes VALUES ('programme-delete', 'tt1234567:1:1', 1, 1, 'Pilot', 'now', NULL)").run();
+    await env.DB.prepare("INSERT INTO show_progress VALUES ('programme-delete', 'tt1234567:1:1')").run();
+    await env.DB.prepare("INSERT INTO current_programmes VALUES (?, 'tv', 'programme-delete', 'tt1234567:1:1', 'now')").bind(householdId).run();
+    await env.DB.prepare("INSERT INTO channel_state VALUES (?, 'tv', 0, 'seed', 'now')").bind(householdId).run();
+    await env.DB.prepare("INSERT INTO channel_schedule VALUES (?, 'tv', 0, 'programme-delete', 'tt1234567:1:1', 'now')").bind(householdId).run();
+    await env.DB.prepare("INSERT INTO channel_advancements VALUES (?, 'tv', 0, 1, 'owner', 'now')").bind(householdId).run();
+    await env.DB.prepare(`INSERT INTO tv_advancement_history VALUES
+      ('history-delete', ?, 0, 1, 'programme-delete', 'tt1234567:1:1', 'programme-delete', 'tt1234567:1:1', '{}', '{}', 'now', NULL, NULL)`).bind(householdId).run();
+    await env.DB.prepare("INSERT INTO movie_channel_state VALUES (?, 1, 0, 'seed', 'now', 0)").bind(householdId).run();
+    await env.DB.prepare("INSERT INTO movie_rotation VALUES (?, 1, 0, 'programme-delete', NULL)").bind(householdId).run();
+    await env.DB.prepare("INSERT INTO movie_advancements VALUES (?, 1, 0, 'owner', 'now')").bind(householdId).run();
+    await env.DB.prepare("INSERT INTO movie_channel_mutations VALUES (?, 0, 'owner', 'now')").bind(householdId).run();
+    await env.DB.prepare("INSERT INTO movie_playback_history VALUES ('movie-history-delete', ?, 'programme-delete', 'tt1234567', 'Delete me', 1, 0, 'now')").bind(householdId).run();
+
+    const deleted = await SELF.fetch(`https://kids.test/api/households/${secret}`, {
+      method: "DELETE", headers, body: JSON.stringify({ currentPin: "123456", confirmation: "DELETE" }),
+    });
+    expect(deleted.status).toBe(200);
+    expect(await deleted.json()).toEqual({ message: "Household permanently deleted." });
+
+    for (const table of ["households", "pin_attempts", "approved_programmes", "show_episodes", "show_progress",
+      "current_programmes", "channel_state", "channel_schedule", "channel_advancements", "tv_advancement_history",
+      "movie_channel_state", "movie_rotation", "movie_advancements", "movie_channel_mutations", "movie_playback_history"]) {
+      expect(await env.DB.prepare(`SELECT COUNT(*) AS count FROM ${table}`).first()).toMatchObject({ count: 0 });
+    }
+
+    const base = `https://kids.test/addons/${secret}`;
+    const invalidated = [
+      created.parentUrl, `${base}/manifest.json`, `${base}/configure`,
+      `${base}/catalog/series/kids-tv-channel.json`, `${base}/meta/series/${encodeURIComponent("kids-channels:tv")}.json`,
+      `${base}/meta/movie/${encodeURIComponent("kids-channels:movie")}.json`,
+      `${base}/stream/series/${encodeURIComponent("tt1234567:1:1")}.json`, `${base}/stream/movie/tt1234567.json`,
+      `${base}/media/movie-sign-off/1/0.mp4`,
+    ];
+    for (const route of invalidated) {
+      const response = await SELF.fetch(route);
+      expect(response.status).toBe(404);
+      expect(await response.text()).not.toContain(secret);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- rate-limit failed Parent PIN checks per Household and Cloudflare request origin
- add current-PIN-protected rotation with immediate Parent session invalidation
- add confirmation- and current-PIN-protected permanent Household deletion
- make recovery limitations and lifecycle controls explicit on the Parent Page
- invalidate all Household Parent and synced Stremio routes after deletion
- document the security behavior and routes

## Tests
- `pnpm test:all`
- `pnpm typecheck`

Closes #15
