### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,14 @@ Use the five canonical triage labels configured for this repository. See `docs/a
 ### Domain docs
 
 This is a single-context repository. See `docs/agents/domain.md`.
+
+## Cursor Cloud specific instructions
+
+Standard setup, run, and test commands live in `README.md` and `package.json` scripts. This is a Cloudflare Worker Stremio addon (TanStack Start SPA + D1) served on `http://localhost:8787` via `pnpm dev`. Notes below are non-obvious caveats for this environment.
+
+- **`.dev.vars` is required and gitignored.** It holds `CONFIG_SECRET` (signs Parent sessions). It already exists in the VM snapshot. If missing, recreate it: `cp .dev.vars.example .dev.vars` then set `CONFIG_SECRET` to `openssl rand -base64 32`. `pnpm dev` and both test suites fail without it.
+- **Local D1 needs migrations applied.** Run `pnpm db:migrate:local` after pulling new files under `migrations/`. Migrations are already applied in the snapshot; local D1 data lives under `.wrangler/` (gitignored, persists in the snapshot). This is deliberately not in the startup update script.
+- **`pnpm dev` has no asset hot-reload.** It runs `pnpm build` (Vite + `scripts/harden-spa-shell.mjs`) once, then `wrangler dev`. Rerun `pnpm dev` after any frontend change to rebuild the SPA shell.
+- **State-changing Parent API calls require a same-origin `Origin` header** (CSRF protection in `src/index.ts`). When testing `POST/PUT/PATCH/DELETE /api/households*` with curl, add `-H "Origin: http://localhost:8787"`, otherwise you get `403 "This request must come from the Parent Page."`.
+- **Lint = `pnpm typecheck`** (`tsc`). There is no separate ESLint script.
+- **Browser tests are self-contained.** `pnpm test:browser` (Playwright) launches its own worker on port 8790 plus a Cinemeta `fetch` stub on 8791 via `scripts/start-browser-test-server.mjs`, against a separate local D1 database `kids-channels-browser` (`wrangler.browser.jsonc`). Chromium is installed via `pnpm exec playwright install chromium`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for the Kids Channels Cloudflare Worker Stremio addon, and documents non-obvious startup caveats for future cloud agents.

The only code change is documentation: a new `## Cursor Cloud specific instructions` section in `AGENTS.md`. All environment state (`.dev.vars`, local D1 migrations, Chromium) is captured in the VM snapshot; the startup update script runs `pnpm install` + `pnpm exec playwright install chromium`.

## Verification

All commands run against Node v22 / pnpm 10 on `http://localhost:8787`:

| Step | Command | Result |
| --- | --- | --- |
| Install | `pnpm install` | ok |
| Lint (typecheck) | `pnpm typecheck` | pass |
| Tests (Worker + component) | `pnpm test` | 38 + 3 pass |
| Browser tests | `pnpm test:browser` | 28 pass |
| Build + run | `pnpm dev` | serves on :8787 |

Hello-world: created a PIN-protected Household through the Parent Page UI; onboarding showed the generated Stremio manifest URL and Parent Page URL, and the dashboard loaded.

[kids_channels_create_household.mp4](https://cursor.com/agents/bc-473dee1f-745e-4960-9488-54b846d0dad6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkids_channels_create_household.mp4)

[Household created onboarding](https://cursor.com/agents/bc-473dee1f-745e-4960-9488-54b846d0dad6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhousehold_created_onboarding.webp)
[Parent dashboard](https://cursor.com/agents/bc-473dee1f-745e-4960-9488-54b846d0dad6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhousehold_parent_dashboard.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-473dee1f-745e-4960-9488-54b846d0dad6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-473dee1f-745e-4960-9488-54b846d0dad6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

