### PR TITLE
Fail over stalled Real-Debrid torrent candidates

### DIFF
--- a/docs/adr/0007-use-first-party-stream-resolution.md
+++ b/docs/adr/0007-use-first-party-stream-resolution.md
@@ -14,5 +14,6 @@ Consequences:
 - Real-Debrid media flows directly to Stremio and signed download URLs are neither persisted nor logged.
 - Provider failure is explicit Channel state rather than an empty stream list that strands playback.
 - Initial selection checks up to ten ranked cached candidates, preserving provider relevance when quality and seed availability tie. If a chosen torrent or restricted link later disappears (including HTTP 451 removals), resolution discards it and tries up to two different hashes inside the same Stremio request. Rate limits and other transient Real-Debrid failures do not invalidate a known-good selection.
+- A pending series torrent is retained while its Real-Debrid progress increases. If it makes no progress for five minutes, the Worker marks that hash stalled for the episode, removes its Real-Debrid job, and attempts the next ranked candidate in the same request. Stalled and terminal hashes are retried after 24 hours so a recovered swarm is not rejected forever. Torrent release titles remain advisory; canonical episode identity and file matching determine eligibility.
 
 This supersedes ADRs 0002 and 0004.

--- a/migrations/0017_track_stream_candidate_health.sql
+++ b/migrations/0017_track_stream_candidate_health.sql
@@ -1,0 +1,22 @@
+ALTER TABLE stream_selections
+  ADD COLUMN last_progress REAL NOT NULL DEFAULT 0;
+
+ALTER TABLE stream_selections
+  ADD COLUMN last_progress_at TEXT;
+
+CREATE TABLE stream_candidate_failures (
+  household_id TEXT NOT NULL,
+  programme_id TEXT NOT NULL,
+  content_type TEXT NOT NULL CHECK (content_type IN ('series', 'movie')),
+  video_id TEXT NOT NULL,
+  info_hash TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  failed_at TEXT NOT NULL,
+  retry_at TEXT NOT NULL,
+  PRIMARY KEY (household_id, content_type, video_id, info_hash),
+  FOREIGN KEY (household_id) REFERENCES households(id) ON DELETE CASCADE,
+  FOREIGN KEY (programme_id) REFERENCES approved_programmes(id) ON DELETE CASCADE
+);
+
+CREATE INDEX stream_candidate_failures_retry_idx
+  ON stream_candidate_failures (household_id, content_type, video_id, retry_at);

--- a/src/stream-selection.ts
+++ b/src/stream-selection.ts
@@ -6,6 +6,9 @@ const CACHE_CHECK_TIMEOUT_MS = 5_000;
 const POLL_INTERVAL_MS = 250;
 const MAX_CACHE_CHECKS = 10;
 const SELECTION_TTL_MS = 24 * 60 * 60 * 1000;
+const DOWNLOAD_STALL_TIMEOUT_MS = 5 * 60 * 1000;
+const CANDIDATE_RETRY_DELAY_MS = 24 * 60 * 60 * 1000;
+const TERMINAL_TORRENT_STATUSES = new Set(["magnet_error", "error", "virus", "dead"]);
 
 export type StreamContentType = "series" | "movie";
 
@@ -58,6 +61,9 @@ interface TorrentInfo {
   status: string;
   files: TorrentFile[];
   links: string[];
+  progress: number;
+  speed: number;
+  seeders: number;
 }
 
 interface ZileanResult {
@@ -89,6 +95,8 @@ interface StoredSelection {
   selected_at: string;
   stale_at: string;
   download_pending: number;
+  last_progress: number;
+  last_progress_at: string | null;
 }
 
 interface StoredSelectionState {
@@ -402,6 +410,9 @@ function torrentInfo(value: unknown): TorrentInfo {
     status: record.status,
     files,
     links: record.links.filter((link): link is string => typeof link === "string"),
+    progress: number(record.progress),
+    speed: number(record.speed),
+    seeders: number(record.seeders),
   };
 }
 
@@ -417,24 +428,32 @@ async function waitForTorrent(
   timeoutMs: number,
 ): Promise<TorrentInfo> {
   const startedAt = performance.now();
+  let lastInfo: TorrentInfo | null = null;
   do {
     const info = torrentInfo(await realDebridJson(
       origin,
       token,
       `/torrents/info/${encodeURIComponent(id)}`,
     ));
+    lastInfo = info;
     if (ready(info)) return info;
-    if (["magnet_error", "error", "virus", "dead"].includes(info.status)) {
-      throw new Error(`Real-Debrid torrent entered ${info.status} state`);
+    if (TERMINAL_TORRENT_STATUSES.has(info.status)) {
+      throw new TorrentTerminalError(info.status);
     }
     await pause(POLL_INTERVAL_MS);
   } while (performance.now() - startedAt < timeoutMs);
-  throw new TorrentDownloadPendingError();
+  throw new TorrentDownloadPendingError(lastInfo);
 }
 
 class TorrentDownloadPendingError extends Error {
-  constructor() {
+  constructor(readonly info: TorrentInfo | null) {
     super("torrent is downloading");
+  }
+}
+
+class TorrentTerminalError extends Error {
+  constructor(readonly status: string) {
+    super(`Real-Debrid torrent entered ${status} state`);
   }
 }
 
@@ -462,7 +481,12 @@ async function cachedCandidate(
   programme: CanonicalProgramme,
   token: string,
   env: StreamSelectionEnv,
-): Promise<{ torrentId: string; file: TorrentFile; downloadPending: boolean } | null> {
+): Promise<{
+  torrentId: string;
+  file: TorrentFile;
+  downloadPending: boolean;
+  progress: number;
+} | { rejectedReason: string } | null> {
   const origin = (env.REAL_DEBRID_ORIGIN || REAL_DEBRID_ORIGIN).replace(/\/$/, "");
   let addedId: string | null = null;
   let matchedFile: TorrentFile | null = null;
@@ -489,18 +513,30 @@ async function cachedCandidate(
       body: formBody({ files: String(file.id) }),
     });
     stage = "confirm-cache";
-    await waitForTorrent(
+    const downloaded = await waitForTorrent(
       origin,
       token,
       addedId,
       (info) => info.status === "downloaded" && info.links.length > 0,
       CACHE_CHECK_TIMEOUT_MS,
     );
-    return { torrentId: addedId, file, downloadPending: false };
+    return { torrentId: addedId, file, downloadPending: false, progress: downloaded.progress };
   } catch (error) {
     if (error instanceof TorrentDownloadPendingError && addedId && matchedFile && stage === "confirm-cache") {
-      return { torrentId: addedId, file: matchedFile, downloadPending: true };
+      return {
+        torrentId: addedId,
+        file: matchedFile,
+        downloadPending: true,
+        progress: error.info?.progress ?? 0,
+      };
     }
+    const rejectedReason = error instanceof TorrentTerminalError
+      ? error.status
+      : error instanceof TorrentDownloadPendingError && stage === "load-files"
+        ? "metadata_timeout"
+        : stage === "match-file"
+          ? "file_mismatch"
+          : null;
     console.warn(JSON.stringify({
       message: "stream candidate rejected",
       stage,
@@ -509,8 +545,70 @@ async function cachedCandidate(
     if (addedId) {
       try { await deleteTorrent(origin, token, addedId); } catch { /* best-effort cleanup */ }
     }
-    return null;
+    return rejectedReason ? { rejectedReason } : null;
   }
+}
+
+async function quarantineInfoHash(
+  db: D1Database,
+  householdId: string,
+  programmeId: string,
+  contentType: StreamContentType,
+  videoId: string,
+  hash: string,
+  reason: string,
+  now: Date,
+): Promise<void> {
+  await db.prepare(`INSERT INTO stream_candidate_failures
+    (household_id, programme_id, content_type, video_id, info_hash, reason, failed_at, retry_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT (household_id, content_type, video_id, info_hash) DO UPDATE SET
+      reason = excluded.reason,
+      failed_at = excluded.failed_at,
+      retry_at = excluded.retry_at`)
+    .bind(
+      householdId,
+      programmeId,
+      contentType,
+      videoId,
+      hash,
+      reason,
+      now.toISOString(),
+      new Date(now.getTime() + CANDIDATE_RETRY_DELAY_MS).toISOString(),
+    )
+    .run();
+}
+
+async function quarantineCandidate(
+  db: D1Database,
+  row: StoredSelection,
+  reason: string,
+  now: Date,
+): Promise<void> {
+  await quarantineInfoHash(
+    db,
+    row.household_id,
+    row.programme_id,
+    row.content_type,
+    row.video_id,
+    row.info_hash,
+    reason,
+    now,
+  );
+}
+
+async function quarantinedInfoHashes(
+  db: D1Database,
+  householdId: string,
+  contentType: StreamContentType,
+  videoId: string,
+  now: Date,
+): Promise<Set<string>> {
+  const { results } = await db.prepare(`SELECT info_hash FROM stream_candidate_failures
+    WHERE household_id = ? AND content_type = ? AND video_id = ? AND retry_at > ?`)
+    .bind(householdId, contentType, videoId, now.toISOString())
+    .all<{ info_hash: string }>();
+  return new Set(results.map((row) => row.info_hash));
 }
 
 async function cachedSelection(
@@ -531,21 +629,13 @@ async function cachedSelection(
     const selection = storedSelection(row);
     if (row.download_pending !== 1) return { selection, downloadPending: false };
     const origin = (env.REAL_DEBRID_ORIGIN || REAL_DEBRID_ORIGIN).replace(/\/$/, "");
+    let info: TorrentInfo;
     try {
-      const info = torrentInfo(await realDebridJson(
+      info = torrentInfo(await realDebridJson(
         origin,
         realDebridToken,
         `/torrents/info/${encodeURIComponent(row.torrent_id)}`,
       ));
-      if (info.status === "downloaded" && info.links.length > 0) {
-        await db.prepare(`UPDATE stream_selections SET download_pending = 0
-          WHERE household_id = ? AND content_type = ? AND video_id = ? AND torrent_id = ?`)
-          .bind(householdId, contentType, videoId, row.torrent_id).run();
-        return { selection, downloadPending: false };
-      }
-      if (!["magnet_error", "error", "virus", "dead"].includes(info.status)) {
-        return { selection, downloadPending: true };
-      }
     } catch (error) {
       console.warn(JSON.stringify({
         message: "pending stream status unavailable",
@@ -553,12 +643,43 @@ async function cachedSelection(
       }));
       return { selection, downloadPending: true };
     }
+    if (info.status === "downloaded" && info.links.length > 0) {
+      await db.prepare(`UPDATE stream_selections SET download_pending = 0
+        WHERE household_id = ? AND content_type = ? AND video_id = ? AND torrent_id = ?`)
+        .bind(householdId, contentType, videoId, row.torrent_id).run();
+      return { selection, downloadPending: false };
+    }
+    if (!TERMINAL_TORRENT_STATUSES.has(info.status)) {
+      const lastHealthyAt = Date.parse(row.last_progress_at ?? row.selected_at);
+      if (info.progress > row.last_progress || info.speed > 0) {
+        await db.prepare(`UPDATE stream_selections
+          SET last_progress = ?, last_progress_at = ?
+          WHERE household_id = ? AND content_type = ? AND video_id = ? AND torrent_id = ?`)
+          .bind(
+            Math.max(info.progress, row.last_progress),
+            now.toISOString(),
+            householdId,
+            contentType,
+            videoId,
+            row.torrent_id,
+          )
+          .run();
+        return { selection, downloadPending: true };
+      }
+      if (!Number.isFinite(lastHealthyAt) || now.getTime() - lastHealthyAt < DOWNLOAD_STALL_TIMEOUT_MS) {
+        return { selection, downloadPending: true };
+      }
+      await quarantineCandidate(db, row, "stalled", now);
+    } else {
+      await quarantineCandidate(db, row, info.status, now);
+    }
     await db.prepare(`DELETE FROM stream_selections
       WHERE household_id = ? AND content_type = ? AND video_id = ? AND torrent_id = ?`)
       .bind(householdId, contentType, videoId, row.torrent_id).run();
     try { await deleteTorrent(origin, realDebridToken, row.torrent_id); } catch { /* allow a new candidate */ }
     return null;
   }
+  if (row.download_pending === 1) await quarantineCandidate(db, row, "expired", now);
   await db.prepare(`DELETE FROM stream_selections
     WHERE household_id = ? AND content_type = ? AND video_id = ?`)
     .bind(householdId, contentType, videoId)
@@ -577,11 +698,12 @@ async function storeSelection(
   db: D1Database,
   selection: StreamSelection,
   downloadPending = false,
+  progress = 0,
 ): Promise<StoredSelectionState> {
   await db.prepare(`INSERT INTO stream_selections
     (household_id, programme_id, content_type, video_id, torrent_id, info_hash, file_id, filename,
-      quality, seeders, selected_at, stale_at, download_pending)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      quality, seeders, selected_at, stale_at, download_pending, last_progress, last_progress_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT (household_id, content_type, video_id) DO NOTHING`)
     .bind(
       selection.householdId,
@@ -597,6 +719,8 @@ async function storeSelection(
       selection.selectedAt,
       selection.staleAt,
       downloadPending ? 1 : 0,
+      progress,
+      downloadPending ? selection.selectedAt : null,
     )
     .run();
   const stored = await db.prepare(`SELECT * FROM stream_selections
@@ -670,12 +794,32 @@ export async function selectCachedStream(
   const programme = await canonicalProgramme(db, householdId, contentType, videoId);
   if (!programme) return null;
 
+  const quarantinedHashes = await quarantinedInfoHashes(db, householdId, contentType, videoId, now);
   const candidates = await discover(programme, env);
-  const eligibleCandidates = candidates.filter((candidate) => !excludedInfoHashes.has(candidate.infoHash));
-  let pending: { candidate: DiscoveryCandidate; torrentId: string; file: TorrentFile } | null = null;
+  const eligibleCandidates = candidates.filter((candidate) =>
+    !excludedInfoHashes.has(candidate.infoHash) && !quarantinedHashes.has(candidate.infoHash));
+  let pending: {
+    candidate: DiscoveryCandidate;
+    torrentId: string;
+    file: TorrentFile;
+    progress: number;
+  } | null = null;
   for (const candidate of eligibleCandidates.slice(0, MAX_CACHE_CHECKS)) {
     const cached = await cachedCandidate(candidate, programme, realDebridToken, env);
     if (!cached) continue;
+    if ("rejectedReason" in cached) {
+      await quarantineInfoHash(
+        db,
+        householdId,
+        programme.programmeId,
+        contentType,
+        videoId,
+        candidate.infoHash,
+        cached.rejectedReason,
+        now,
+      );
+      continue;
+    }
     if (cached.downloadPending) {
       if (contentType !== "series") {
         try {
@@ -687,7 +831,12 @@ export async function selectCachedStream(
         } catch { /* movies retain the existing cached-only behavior */ }
         continue;
       }
-      if (!pending) pending = { candidate, torrentId: cached.torrentId, file: cached.file };
+      if (!pending) pending = {
+        candidate,
+        torrentId: cached.torrentId,
+        file: cached.file,
+        progress: cached.progress,
+      };
       else {
         try {
           await deleteTorrent(
@@ -740,7 +889,7 @@ export async function selectCachedStream(
       now,
     );
     try {
-      const stored = await storeSelection(db, selection, true);
+      const stored = await storeSelection(db, selection, true, pending.progress);
       if (stored.selection.torrentId !== selection.torrentId) {
         try {
           await deleteTorrent(

--- a/test/secrets.test.ts
+++ b/test/secrets.test.ts
@@ -15,7 +15,9 @@ describe("stream resolution tokens", () => {
       fileId: 7,
     });
     expect(await verifyStreamToken(token, "household-two", configurationSecret, now)).toBeNull();
-    expect(await verifyStreamToken(`${token.slice(0, -1)}x`, "household-one", configurationSecret, now)).toBeNull();
+    const [payload, signature] = token.split(".");
+    const forged = `${payload}.${signature.startsWith("A") ? "B" : "A"}${signature.slice(1)}`;
+    expect(await verifyStreamToken(forged, "household-one", configurationSecret, now)).toBeNull();
     expect(await verifyStreamToken(token, "household-one", configurationSecret, expiresAt)).toBeNull();
   });
 

--- a/test/stream-selection.test.ts
+++ b/test/stream-selection.test.ts
@@ -49,8 +49,22 @@ beforeEach(async () => {
     selected_at TEXT NOT NULL,
     stale_at TEXT NOT NULL,
     download_pending INTEGER NOT NULL DEFAULT 0,
+    last_progress REAL NOT NULL DEFAULT 0,
+    last_progress_at TEXT,
     PRIMARY KEY (household_id, content_type, video_id)
   )`).run();
+  await env.DB.prepare(`CREATE TABLE IF NOT EXISTS stream_candidate_failures (
+    household_id TEXT NOT NULL,
+    programme_id TEXT NOT NULL,
+    content_type TEXT NOT NULL,
+    video_id TEXT NOT NULL,
+    info_hash TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    failed_at TEXT NOT NULL,
+    retry_at TEXT NOT NULL,
+    PRIMARY KEY (household_id, content_type, video_id, info_hash)
+  )`).run();
+  await env.DB.prepare("DELETE FROM stream_candidate_failures").run();
   await env.DB.prepare("DELETE FROM stream_selections").run();
   await env.DB.prepare("DELETE FROM show_episodes").run();
   await env.DB.prepare("DELETE FROM approved_programmes").run();
@@ -225,6 +239,8 @@ describe("cached stream selection", () => {
       video_id: "tt1234567:1:2",
       file_id: 2,
     });
+    expect(await env.DB.prepare("SELECT COUNT(*) AS count FROM stream_candidate_failures").first())
+      .toMatchObject({ count: uncachedHashes.length });
 
     const requestCount = outbound.mock.calls.length;
     expect(await selectCachedStream(
@@ -256,6 +272,7 @@ describe("cached stream selection", () => {
     const hash = "a".repeat(40);
     let selected = false;
     let downloaded = false;
+    let progress = 0;
     let addCount = 0;
     const deleted: string[] = [];
     vi.useFakeTimers();
@@ -283,6 +300,9 @@ describe("cached stream selection", () => {
       if (url.pathname.endsWith("/torrents/info/queued-torrent")) {
         return Response.json({
           status: downloaded ? "downloaded" : selected ? "downloading" : "waiting_files_selection",
+          progress,
+          speed: 0,
+          seeders: 0,
           files: [{ id: 2, path: "/Example.Show.S01E02.1080p.mkv", bytes: 1_000 }],
           links: downloaded ? ["https://restricted.test/file"] : [],
         });
@@ -314,6 +334,20 @@ describe("cached stream selection", () => {
     expect(await env.DB.prepare("SELECT torrent_id, file_id, download_pending FROM stream_selections").first())
       .toMatchObject({ torrent_id: "queued-torrent", file_id: 2, download_pending: 1 });
 
+    progress = 12;
+    expect(await selectCachedStream(
+      env.DB,
+      "household",
+      "series",
+      "tt1234567:1:2",
+      "rd-token",
+      options,
+      new Date("2026-07-30T00:06:00.000Z"),
+    )).toBeNull();
+    expect(await env.DB.prepare("SELECT last_progress, last_progress_at FROM stream_selections").first())
+      .toMatchObject({ last_progress: 12, last_progress_at: "2026-07-30T00:06:00.000Z" });
+    expect(addCount).toBe(1);
+
     downloaded = true;
     expect(await selectCachedStream(
       env.DB,
@@ -327,5 +361,117 @@ describe("cached stream selection", () => {
     expect(await env.DB.prepare("SELECT download_pending FROM stream_selections").first())
       .toMatchObject({ download_pending: 0 });
     expect(addCount).toBe(1);
+  });
+
+  it("quarantines a stalled pending torrent and tries the next ranked candidate", async () => {
+    await env.DB.prepare(`INSERT INTO households (id, secret, pin_salt, pin_hash, created_at)
+      VALUES ('household', 'secret', 'salt', 'hash', 'now')`).run();
+    await env.DB.prepare(`INSERT INTO approved_programmes
+      (id, household_id, imdb_id, content_type, title, release_info, genres_json, approved_at)
+      VALUES ('programme', 'household', 'tt1234567', 'show', 'Example Show', '2024', '[]', 'now')`).run();
+    await env.DB.prepare(`INSERT INTO show_episodes
+      (programme_id, video_id, season, episode, title, released_at)
+      VALUES ('programme', 'tt1234567:1:2', 1, 2, 'Second', '2024-01-01')`).run();
+
+    const firstHash = "a".repeat(40);
+    const secondHash = "b".repeat(40);
+    const additions = new Map<string, number>();
+    const selected = new Set<string>();
+    const deleted: string[] = [];
+    vi.useFakeTimers();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = new URL(input instanceof Request ? input.url : input.toString());
+      if (url.hostname === "zilean.test") {
+        return Response.json([
+          {
+            raw_title: "Example.Show.S01E02.1080p.WEB-DL",
+            info_hash: firstHash,
+            resolution: "1080p",
+            seasons: [1],
+            episodes: [2],
+          },
+          {
+            raw_title: "Example.Show.S01E02.720p.WEB-DL",
+            info_hash: secondHash,
+            resolution: "720p",
+            seasons: [1],
+            episodes: [2],
+          },
+        ]);
+      }
+      if (url.hostname === "knaben.test") return Response.json({ hits: [] });
+      if (url.pathname.endsWith("/torrents/addMagnet")) {
+        const magnet = (init?.body as URLSearchParams).get("magnet")!;
+        const hash = new URL(magnet).searchParams.get("xt")!.split(":").at(-1)!;
+        const attempt = (additions.get(hash) ?? 0) + 1;
+        additions.set(hash, attempt);
+        return Response.json({ id: `torrent-${hash}-${attempt}` });
+      }
+      const infoMatch = url.pathname.match(/\/torrents\/info\/(torrent-(.+)-(\d+))$/);
+      if (infoMatch) {
+        const [, id, hash, attemptText] = infoMatch;
+        const attempt = Number(attemptText);
+        const ready = hash === secondHash && attempt === 2 && selected.has(id);
+        return Response.json({
+          status: ready ? "downloaded" : selected.has(id) ? "downloading" : "waiting_files_selection",
+          progress: 0,
+          speed: 0,
+          seeders: 0,
+          files: [{ id: 2, path: "/Example.Show.S01E02.mkv", bytes: 1_000 }],
+          links: ready ? ["https://restricted.test/file"] : [],
+        });
+      }
+      const selectMatch = url.pathname.match(/\/torrents\/selectFiles\/(torrent-.+)$/);
+      if (selectMatch) {
+        selected.add(selectMatch[1]);
+        return new Response(null, { status: 204 });
+      }
+      const deleteMatch = url.pathname.match(/\/torrents\/delete\/(torrent-.+)$/);
+      if (deleteMatch) {
+        deleted.push(deleteMatch[1]);
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`unexpected request ${url}`);
+    });
+    const options = {
+      ZILEAN_ORIGIN: "https://zilean.test",
+      KNABEN_ORIGIN: "https://knaben.test",
+      REAL_DEBRID_ORIGIN: "https://real-debrid.test/rest/1.0",
+    };
+
+    const initialRequest = selectCachedStream(
+      env.DB,
+      "household",
+      "series",
+      "tt1234567:1:2",
+      "rd-token",
+      options,
+      new Date("2026-07-30T00:00:00.000Z"),
+    );
+    await vi.advanceTimersByTimeAsync(11_000);
+    expect(await initialRequest).toBeNull();
+    expect(await env.DB.prepare("SELECT info_hash, download_pending FROM stream_selections").first())
+      .toMatchObject({ info_hash: firstHash, download_pending: 1 });
+
+    const replacement = await selectCachedStream(
+      env.DB,
+      "household",
+      "series",
+      "tt1234567:1:2",
+      "rd-token",
+      options,
+      new Date("2026-07-30T00:06:00.000Z"),
+    );
+
+    expect(replacement).toMatchObject({ infoHash: secondHash, torrentId: `torrent-${secondHash}-2` });
+    expect(additions.get(firstHash)).toBe(1);
+    expect(deleted).toContain(`torrent-${firstHash}-1`);
+    expect(await env.DB.prepare("SELECT info_hash, reason, retry_at FROM stream_candidate_failures").first())
+      .toMatchObject({
+        info_hash: firstHash,
+        reason: "stalled",
+        retry_at: "2026-07-31T00:06:00.000Z",
+      });
   });
 });

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -109,7 +109,14 @@ beforeEach(async () => {
     torrent_id TEXT NOT NULL, info_hash TEXT NOT NULL, file_id INTEGER NOT NULL, filename TEXT NOT NULL,
     quality TEXT NOT NULL, seeders INTEGER NOT NULL, selected_at TEXT NOT NULL, stale_at TEXT NOT NULL,
     download_pending INTEGER NOT NULL DEFAULT 0,
+    last_progress REAL NOT NULL DEFAULT 0, last_progress_at TEXT,
     PRIMARY KEY (household_id, content_type, video_id)
+  )`).run();
+  await env.DB.prepare(`CREATE TABLE IF NOT EXISTS stream_candidate_failures (
+    household_id TEXT NOT NULL, programme_id TEXT NOT NULL, content_type TEXT NOT NULL,
+    video_id TEXT NOT NULL, info_hash TEXT NOT NULL,
+    reason TEXT NOT NULL, failed_at TEXT NOT NULL, retry_at TEXT NOT NULL,
+    PRIMARY KEY (household_id, content_type, video_id, info_hash)
   )`).run();
   await env.DB.prepare(`CREATE TABLE IF NOT EXISTS unavailable_episodes (
     household_id TEXT NOT NULL, programme_id TEXT NOT NULL, video_id TEXT NOT NULL,
@@ -119,6 +126,7 @@ beforeEach(async () => {
   await env.DB.prepare("CREATE INDEX IF NOT EXISTS households_secret_idx ON households (secret)").run();
   await env.DB.prepare("DELETE FROM pin_attempts").run();
   await env.DB.prepare("DELETE FROM unavailable_episodes").run();
+  await env.DB.prepare("DELETE FROM stream_candidate_failures").run();
   await env.DB.prepare("DELETE FROM stream_selections").run();
   await env.DB.prepare("DELETE FROM movie_playback_history").run();
   await env.DB.prepare("DELETE FROM movie_channel_mutations").run();
@@ -878,7 +886,9 @@ describe("TV Channel client-side stream resolution", () => {
       throw new Error(`unexpected outbound request: ${url}`);
     });
 
-    const forged = await SELF.fetch(`${base}/resolve/${token.slice(0, -1)}x`, { redirect: "manual" });
+    const [payload, signature] = token.split(".");
+    const forgedToken = `${payload}.${signature.startsWith("A") ? "B" : "A"}${signature.slice(1)}`;
+    const forged = await SELF.fetch(`${base}/resolve/${forgedToken}`, { redirect: "manual" });
     expect(forged.status).toBe(403);
     expect(realDebrid).not.toHaveBeenCalled();
     expect(await env.DB.prepare("SELECT COUNT(*) AS count FROM stream_selections").first()).toMatchObject({ count: 1 });
@@ -1689,7 +1699,7 @@ describe("Household deletion", () => {
     for (const table of ["households", "pin_attempts", "approved_programmes", "show_episodes", "show_progress",
       "current_programmes", "channel_state", "channel_schedule", "channel_advancements", "tv_advancement_history",
       "movie_channel_state", "movie_rotation", "movie_advancements", "movie_channel_mutations", "movie_playback_history",
-      "stream_selections", "unavailable_episodes"]) {
+      "stream_selections", "stream_candidate_failures", "unavailable_episodes"]) {
       expect(await env.DB.prepare(`SELECT COUNT(*) AS count FROM ${table}`).first()).toMatchObject({ count: 0 });
     }
 


### PR DESCRIPTION
## Summary

- track Real-Debrid download progress for pending series torrents
- quarantine stalled, terminal, metadata-timeout, and file-mismatch hashes per episode
- remove stalled Real-Debrid jobs and try the next ranked candidate in the same request
- retry quarantined hashes after 24 hours and preserve progressing or transiently unavailable downloads
- document the resolver behavior and add the D1 migration

## Verification

- `pnpm test`
- `pnpm typecheck`
- all 17 D1 migrations applied successfully against a clean local database

## Notes

The stall threshold is five minutes. Torrent release titles were not made a hard semantic-title check; canonical episode identity and file matching remain authoritative.