### PR TITLE
Automatically keep the TV schedule warm

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,7 +37,7 @@ The Current Programme followed by the upcoming programmes selected for continuou
 _Avoid_: Queue, playlist
 
 **Preparation Run**:
-A Parent-triggered, time-bounded background attempt to make programmes in the current Channel Schedule ready in TorBox. It checks cached candidates first and may start one matching download per programme. It does not advance the Channel Schedule or Show Progress.
+An automatically triggered, time-bounded background attempt to keep the next twenty programmes in the current Channel Schedule ready in TorBox. It checks cached candidates first and may start one matching download per programme. It does not advance the Channel Schedule or Show Progress.
 _Avoid_: Seeder, download queue, preload
 
 **Unavailable Episode**:

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -23,6 +23,7 @@ Unlike Stremio's open catalogue or algorithmic kids' profiles, a Channel here is
 - The Parent Page is reached via a private, unrecoverable Household URL; sessions expire after one hour and can be locked.
 - Installation happens once per Household: a Stremio addon (manifest URL) installed on the Stremio account shared by the Household's devices, completed on desktop.
 - Streams are resolved through the Household's encrypted TorBox API token. Kids Channels discovers candidates, checks exact episode files, prefers cached sources, and prepares one uncached series source when necessary.
+- The next twenty scheduled TV episodes are warmed automatically. Schedule changes trigger immediate reconciliation and a periodic safety check repairs expired or missed preparation.
 - Changes to Channel state require a Stremio restart to take effect.
 
 ## Capabilities and Constraints

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Keep `.dev.vars` private; `CONFIG_SECRET` signs one-hour Parent sessions. Open `
 
 Stremio retains loaded addon metadata in memory even when responses use `Cache-Control: no-store`. After a Parent changes the Approved Library or regenerates selections, fully close and reopen Stremio to load the updated Channel. The Worker state changes immediately and does not interrupt media already playing.
 
+When TorBox is connected, Kids Channels automatically warms the next twenty TV episodes. Every schedule advancement or correction reconciles the active Preparation Run in the background, and a fifteen-minute scheduled check restarts preparation when a selection expires or an earlier trigger was missed. The Parent Page reports progress but does not require a manual preparation action.
+
 Local D1 data is stored by Wrangler under `.wrangler/`. There is no forgotten-PIN or account recovery. Five incorrect PIN attempts from one request origin within 15 minutes lock PIN access from that origin for 15 minutes for that Household only. A Parent can rotate the PIN by supplying the current PIN; rotation invalidates older Parent sessions. Permanent deletion requires the current PIN plus the exact confirmation `DELETE`, removes all Household data, and invalidates every synced addon route.
 
 ## Test

--- a/docs/MVP.md
+++ b/docs/MVP.md
@@ -13,6 +13,7 @@ The household rule—not technical restrictions—keeps children out of Stremio'
 - Stremio may show a detail page requiring one Play action if Fire TV cannot start directly from a Channel tile.
 - Kids Channels returns exactly one ready source at programme transitions, without exposing source selection.
 - Upcoming TV programmes may be visible and selectable. Selecting a distant programme skips bypassed programmes; the Parent can correct Show Progress.
+- With TorBox connected, automatically keep the next twenty scheduled TV episodes prepared without a Parent action.
 
 ## Parent Page
 

--- a/docs/adr/0008-prepare-tv-schedule-with-cloudflare-workflows.md
+++ b/docs/adr/0008-prepare-tv-schedule-with-cloudflare-workflows.md
@@ -1,6 +1,6 @@
 # Prepare the TV Channel Schedule with Cloudflare Workflows
 
-Status: Superseded for provider and concurrency policy by ADR 0009. The Workflow design remains in force.
+Status: Superseded for provider and concurrency policy by ADR 0009, and for manual orchestration by ADR 0010. The bounded Workflow design remains in force.
 
 Kids Channels will let a Parent manually start a time-bounded Preparation Run for up to twenty programmes in the current Channel Schedule. The run snapshots those programmes, uses the Household's existing Real-Debrid credential to add and monitor torrent candidates, and continues in a Cloudflare Workflow after the Parent closes the page. It does not advance the Channel Schedule or Show Progress.
 

--- a/docs/adr/0009-use-torbox-for-preparation-and-playback.md
+++ b/docs/adr/0009-use-torbox-for-preparation-and-playback.md
@@ -8,6 +8,8 @@ Playback verifies that the stored TorBox torrent and file are still ready, reque
 
 TorBox permits simultaneous use from multiple IP addresses and devices, so Preparation Runs may continue while the Household watches the Channel. TorBox plan limits, active download slots, and fair-use controls still apply. The Parent Page no longer presents the Real-Debrid idle-account warning or the experimental provider probe.
 
+ADR 0010 replaces manual Preparation Run controls with automatic rolling warm-up while retaining the TorBox selection and playback decisions in this ADR.
+
 Consequences:
 
 - Existing Real-Debrid credentials remain only as unused historical database columns; the migration clears provider-specific stream selections and candidate failures.

--- a/docs/adr/0010-automatically-warm-the-tv-channel-schedule.md
+++ b/docs/adr/0010-automatically-warm-the-tv-channel-schedule.md
@@ -1,0 +1,18 @@
+# Automatically warm the TV Channel Schedule
+
+Kids Channels will automatically keep up to twenty programmes from the current Channel Schedule ready in TorBox. The Parent Page reports warm-up state but does not start, configure, or stop Preparation Runs.
+
+Connecting or replacing TorBox and every TV schedule mutation trigger reconciliation through `ExecutionContext.waitUntil()`, keeping torrent work outside the response path. If the active run already represents the same schedule snapshot, it is reused. If the schedule has rolled forward or changed, the run is cancelled and replaced with a new twenty-programme snapshot. Existing TorBox downloads and valid D1 stream selections remain available to the replacement run.
+
+Each run remains bounded to eight hours and uses the existing five-minute Workflow rounds. A cron trigger runs every fifteen minutes as a safety net. It selects configured Households that have no active run and at least one scheduled episode without a fresh ready selection, then starts another bounded run. Processing at most one hundred eligible Households per invocation prevents an unbounded scheduled event; households with a newly active run leave the eligible set so later invocations can progress through the remainder.
+
+Consequences:
+
+- The first schedule is warmed after TorBox is connected or an approved show creates a schedule.
+- When playback advances the Channel, the newly appended twentieth episode is included in a replacement run automatically.
+- Show Progress corrections, undo, regeneration, pause, resume, removal, and show approval also reconcile warm-up.
+- Disconnecting TorBox stops the active run before clearing the encrypted credential and stream selections.
+- A completed run is not permanently final: the cron starts a later run if a 24-hour selection expires or any scheduled episode is still not ready.
+- Manual preparation POST and cancellation routes are removed; the authenticated GET status route remains for the Parent Page.
+
+This supersedes the manual trigger, configurable count/window, and Parent cancellation portions of ADR 0008. ADR 0008's bounded Cloudflare Workflow execution model remains in force.

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,8 +48,10 @@ import {
 } from "./stream-resolution";
 import { selectCachedStream, type StreamContentType } from "./stream-selection";
 import {
-  cancelTvPreparationRun,
-  createTvPreparationRun,
+  ensureAutomaticTvPreparation,
+  ensureAutomaticTvPreparationForAll,
+  restartAutomaticTvPreparation,
+  stopAutomaticTvPreparation,
   tvPreparationRun,
   TvSchedulePreparationWorkflow,
   type TvPreparationWorkflowParams,
@@ -75,6 +77,7 @@ export interface Env {
   TORBOX_ORIGIN?: string;
   ZILEAN_ORIGIN?: string;
   KNABEN_ORIGIN?: string;
+  AUTOMATIC_TV_PREPARATION_DISABLED?: string;
   TV_PREPARATION: Workflow<TvPreparationWorkflowParams>;
 }
 
@@ -95,6 +98,16 @@ function json(value: unknown, status = 200, headers?: HeadersInit): Response {
 
 function addonJson(value: unknown, status = 200, headers?: HeadersInit): Response {
   return json(value, status, { "access-control-allow-origin": "*", ...headers });
+}
+
+function queueAutomaticTvPreparation(env: Env, ctx: ExecutionContext, householdId: string): void {
+  ctx.waitUntil(ensureAutomaticTvPreparation(env, householdId).catch((error) => {
+    console.error(JSON.stringify({
+      message: "automatic TV preparation trigger failed",
+      householdId,
+      reason: error instanceof Error ? error.message : "unknown error",
+    }));
+  }));
 }
 
 async function householdNotFoundResponse(request: Request, assets?: Fetcher): Promise<Response> {
@@ -227,7 +240,7 @@ function hasSameOrigin(request: Request): boolean {
 }
 
 export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
     const path = url.pathname;
 
@@ -343,6 +356,7 @@ export default {
         return json(await torBoxCredentialStatus(env.DB, household.id), 200, { "cache-control": "no-store" });
       }
       if (request.method === "DELETE") {
+        await stopAutomaticTvPreparation(env, household.id, "Stopped because TorBox was disconnected");
         await clearTorBoxCredential(env.DB, household.id);
         return json(
           { configured: false, updatedAt: null, message: "TorBox disconnected. Channel playback is unavailable until another token is saved." },
@@ -363,6 +377,13 @@ export default {
         return json({ error: "TorBox could not validate this token right now. Nothing was saved." }, 502, { "cache-control": "no-store" });
       }
       const status = await storeTorBoxCredential(env.DB, household.id, input.token, env.CONFIG_SECRET);
+      ctx.waitUntil(restartAutomaticTvPreparation(env, household.id).catch((error) => {
+        console.error(JSON.stringify({
+          message: "automatic TV preparation could not restart after TorBox connection changed",
+          householdId: household.id,
+          reason: error instanceof Error ? error.message : "unknown error",
+        }));
+      }));
       return json(
         { ...status, message: "TorBox connected. The token is stored encrypted for this Household." },
         200,
@@ -444,6 +465,7 @@ export default {
         if (!title) return json({ error: "Programme was not found in Cinemeta." }, 404);
         const programme = await approveProgramme(env.DB, household.id, title, input.startingEpisodeId);
         if (programme.type === "movie") await reconcileMovieChannel(env.DB, household.id, env.MOVIE_ROTATION_SEED);
+        else queueAutomaticTvPreparation(env, ctx, household.id);
         return json({ programme }, 201);
       } catch (error) {
         const message = error instanceof Error ? error.message : "";
@@ -485,6 +507,7 @@ export default {
         await env.DB.prepare("UPDATE approved_programmes SET paused_at = ? WHERE id = ? AND household_id = ?")
           .bind(pausedAt, programme.id, household.id).run();
         await refreshTvChannelSchedule(env.DB, household.id, false, env.TV_SCHEDULE_SEED);
+        queueAutomaticTvPreparation(env, ctx, household.id);
         return json({ message: `${input.paused ? "Show paused without changing Show Progress." : "Show resumed."} Restart Stremio to refresh the Channel.` });
       }
 
@@ -497,6 +520,7 @@ export default {
           env.DB.prepare("DELETE FROM approved_programmes WHERE id = ? AND household_id = ?").bind(programme.id, household.id),
         ]);
         await refreshTvChannelSchedule(env.DB, household.id, false, env.TV_SCHEDULE_SEED);
+        queueAutomaticTvPreparation(env, ctx, household.id);
       } else {
         await removeApprovedMovie(env.DB, household.id, programme.id, env.MOVIE_ROTATION_SEED);
       }
@@ -526,64 +550,12 @@ export default {
     }
 
     const preparationMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/tv-preparation$/);
-    if (preparationMatch && (request.method === "GET" || request.method === "POST")) {
+    if (preparationMatch && request.method === "GET") {
       const household = await findHousehold(env.DB, preparationMatch[1]);
       if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household, env.CONFIG_SECRET))) {
         return json({ error: "Parent authentication is required." }, 401, { "cache-control": "no-store" });
       }
-      if (request.method === "GET") {
-        return json({ run: await tvPreparationRun(env.DB, household.id) }, 200, { "cache-control": "no-store" });
-      }
-      let input: { count?: unknown; windowHours?: unknown } = {};
-      try { input = await request.json() as typeof input; } catch { /* handled below */ }
-      const count = Number(input.count);
-      const windowHours = Number(input.windowHours);
-      if (!Number.isInteger(count) || count < 1 || count > 20) {
-        return json({ error: "Choose between 1 and 20 programmes." }, 400);
-      }
-      if (![1, 4, 8].includes(windowHours)) {
-        return json({ error: "Choose a preparation window of 1, 4, or 8 hours." }, 400);
-      }
-      if (!(await loadTorBoxCredential(env.DB, household.id, env.CONFIG_SECRET))) {
-        return json({ error: "Configure TorBox before starting a Preparation Run." }, 409);
-      }
-      const schedule = await tvChannelSchedule(env.DB, household.id, env.TV_SCHEDULE_SEED);
-      if (!schedule.length) return json({ error: "The TV Channel has no programmes to prepare." }, 409);
-      try {
-        const run = await createTvPreparationRun(env.DB, household.id, schedule, count, windowHours);
-        try {
-          await env.TV_PREPARATION.create({
-            id: run.id,
-            params: { runId: run.id, householdId: household.id },
-            retention: { successRetention: "7 days", errorRetention: "7 days" },
-          });
-        } catch (error) {
-          const timestamp = new Date().toISOString();
-          await env.DB.prepare(`UPDATE tv_preparation_runs
-            SET status = 'failed', failure_reason = ?, completed_at = ?, updated_at = ? WHERE id = ?`)
-            .bind("Cloudflare could not start the Preparation Run.", timestamp, timestamp, run.id).run();
-          throw error;
-        }
-        return json({ run }, 202, { "cache-control": "no-store" });
-      } catch (error) {
-        if (error instanceof Error && error.message === "preparation already active") {
-          return json({ error: "A Preparation Run is already active for this Household." }, 409);
-        }
-        console.error(JSON.stringify({ message: "TV preparation could not start", reason: error instanceof Error ? error.message : "unknown error" }));
-        return json({ error: "The Preparation Run could not be started." }, 503);
-      }
-    }
-
-    const preparationCancelMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/tv-preparation\/cancel$/);
-    if (request.method === "POST" && preparationCancelMatch) {
-      const household = await findHousehold(env.DB, preparationCancelMatch[1]);
-      if (!household || !env.CONFIG_SECRET || !(await authorizedParent(request, household, env.CONFIG_SECRET))) {
-        return json({ error: "Parent authentication is required." }, 401, { "cache-control": "no-store" });
-      }
-      const run = await cancelTvPreparationRun(env.DB, household.id);
-      if (!run) return json({ error: "There is no active Preparation Run to stop." }, 409);
-      try { await (await env.TV_PREPARATION.get(run.id)).terminate(); } catch { /* database status prevents further useful work */ }
-      return json({ run }, 200, { "cache-control": "no-store" });
+      return json({ run: await tvPreparationRun(env.DB, household.id) }, 200, { "cache-control": "no-store" });
     }
 
     const movieStateMatch = path.match(/^\/api\/households\/([A-Za-z0-9_-]+)\/movie-state$/);
@@ -622,6 +594,7 @@ export default {
         }
         throw error;
       }
+      queueAutomaticTvPreparation(env, ctx, household.id);
       return json({ message: "Show Progress corrected and incompatible future selections repaired. The active stream was not interrupted. Restart Stremio to refresh the Channel." });
     }
 
@@ -633,6 +606,7 @@ export default {
       }
       const undone = await undoLatestTvAdvancement(env.DB, household.id, env.TV_SCHEDULE_SEED);
       if (!undone) return json({ error: "There is no latest TV advancement to undo." }, 409);
+      queueAutomaticTvPreparation(env, ctx, household.id);
       return json({ message: "Most recent advancement undone without changing later corrections to other shows. The active stream was not interrupted. Restart Stremio to refresh the Channel." });
     }
 
@@ -643,6 +617,7 @@ export default {
         return json({ error: "Parent authentication is required." }, 401);
       }
       await refreshTvChannelSchedule(env.DB, household.id, true, env.TV_SCHEDULE_SEED);
+      queueAutomaticTvPreparation(env, ctx, household.id);
       return json({ message: "Upcoming TV selections regenerated without changing the Current Programme or Show Progress. Restart Stremio to refresh the Channel." });
     }
 
@@ -817,6 +792,7 @@ export default {
         if (!torBoxToken) {
           if (streamMatch[2] === "series") {
             await requestTvProgramme(env.DB, household.id, videoId, env.TV_SCHEDULE_SEED);
+            queueAutomaticTvPreparation(env, ctx, household.id);
           }
           return addonJson({ streams: [] }, 200, { "cache-control": "no-store" });
         }
@@ -833,6 +809,7 @@ export default {
             return addonJson({ streams: [] }, 200, { "cache-control": "no-store" });
           }
           await requestTvProgramme(env.DB, household.id, videoId, env.TV_SCHEDULE_SEED);
+          queueAutomaticTvPreparation(env, ctx, household.id);
           const deferred = await deferUnavailableTvProgramme(
             env.DB,
             household.id,
@@ -854,6 +831,7 @@ export default {
         if (streamMatch[2] === "series") {
           await clearUnavailableTvProgramme(env.DB, household.id, videoId);
           await requestTvProgramme(env.DB, household.id, videoId, env.TV_SCHEDULE_SEED);
+          queueAutomaticTvPreparation(env, ctx, household.id);
         }
         const resolveToken = await issueStreamToken(
           household.id,
@@ -879,5 +857,8 @@ export default {
     }
 
     return json({ error: "Not found." }, 404);
+  },
+  async scheduled(_controller: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
+    ctx.waitUntil(ensureAutomaticTvPreparationForAll(env));
   },
 } satisfies ExportedHandler<Env>;

--- a/src/routes/households.$secret.tv-channel.tsx
+++ b/src/routes/households.$secret.tv-channel.tsx
@@ -7,7 +7,6 @@ import { StateBadge } from "../components/StateBadge";
 import { Button } from "../components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "../components/ui/dialog";
 import { Skeleton } from "../components/ui/skeleton";
-import { NativeSelect } from "../components/ui/native-select";
 import { useTvChannel, useTvPreparation } from "../lib/channel-queries";
 import { apiErrorMessage, parentApi, parentKeys } from "../lib/parent-api";
 
@@ -80,43 +79,12 @@ function TvChannelPage() {
   const [mutationStatus, setMutationStatus] = useState("");
   const [mutationFailed, setMutationFailed] = useState(false);
   const [confirmingRegeneration, setConfirmingRegeneration] = useState(false);
-  const [confirmingPreparation, setConfirmingPreparation] = useState(false);
-  const [preparationCount, setPreparationCount] = useState(20);
-  const [preparationHours, setPreparationHours] = useState(8);
-  const [preparationMessage, setPreparationMessage] = useState("");
-  const [preparationFailed, setPreparationFailed] = useState(false);
   const actionMutation = useMutation({
     mutationFn: async (kind: "undo" | "regenerate") => {
       const path = kind === "undo" ? "/tv-schedule/undo" : "/tv-schedule/regenerate";
       return parentApi<{ message?: string }>(`${base}${path}`, { method: "POST" });
     },
   });
-  const preparationMutation = useMutation({
-    mutationFn: (action: "start" | "cancel") => parentApi<{ run: PreparationRun }>(
-      action === "start" ? `${base}/tv-preparation` : `${base}/tv-preparation/cancel`,
-      action === "start"
-        ? { method: "POST", body: { count: Math.min(preparationCount, state?.schedule.length ?? 20), windowHours: preparationHours } }
-        : { method: "POST" },
-    ),
-  });
-
-  async function changePreparation(action: "start" | "cancel") {
-    if (preparationMutation.isPending) return;
-    setPreparationMessage("");
-    setPreparationFailed(false);
-    try {
-      await preparationMutation.mutateAsync(action);
-      await queryClient.invalidateQueries({ queryKey: parentKeys.tvPreparation(secret) });
-      setPreparationMessage(action === "start"
-        ? "Preparation started. You can close this page while Cloudflare continues."
-        : "Preparation stopped. TorBox keeps anything already added or cached.");
-    } catch (error) {
-      setPreparationFailed(true);
-      setPreparationMessage(apiErrorMessage(error, `Preparation could not be ${action === "start" ? "started" : "stopped"}. Check your connection and try again.`));
-      throw error;
-    }
-  }
-
   async function performAction(kind: "undo" | "regenerate") {
     if (actionMutation.isPending) return;
     setMutationStatus("");
@@ -138,7 +106,6 @@ function TvChannelPage() {
   const visibleHistory = historyExpanded ? history : history.slice(0, HISTORY_PREVIEW_SIZE);
   const preparation = preparationQuery.data?.run;
   const preparationActive = preparation?.status === "queued" || preparation?.status === "running";
-  const countLimit = Math.max(1, Math.min(20, state?.schedule.length ?? 20));
 
   return (
     <section className="grid gap-10" aria-labelledby="page-heading">
@@ -170,42 +137,21 @@ function TvChannelPage() {
           </section>
 
           <section className="rounded-[4px] border bg-card p-5" aria-labelledby="preparation-heading">
-            <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
-              <div className="max-w-2xl">
-                <Ident className="mb-2">TorBox</Ident>
-                <h2 id="preparation-heading" className="text-xl font-semibold tracking-[-0.01em]">Prepare for later</h2>
-                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">Ask TorBox to cache programmes from this Channel Schedule. Cloudflare keeps trying usable alternatives during the selected window, even after you close this page.</p>
-                <p className="mt-3 text-sm leading-relaxed text-muted-foreground">Preparation may run while the Channel is being watched. It checks cached sources first, then queues one matching uncached source when needed.</p>
-              </div>
-              {!preparationActive && (
-                <div className="grid shrink-0 grid-cols-2 gap-2 max-sm:w-full">
-                  <label className="grid gap-1 text-xs font-medium text-muted-foreground">Programmes
-                    <NativeSelect value={Math.min(preparationCount, countLimit)} onChange={(event) => setPreparationCount(Number(event.target.value))}>
-                      {Array.from({ length: countLimit }, (_, index) => index + 1).map((count) => <option key={count} value={count}>{count}</option>)}
-                    </NativeSelect>
-                  </label>
-                  <label className="grid gap-1 text-xs font-medium text-muted-foreground">Time window
-                    <NativeSelect value={preparationHours} onChange={(event) => setPreparationHours(Number(event.target.value))}>
-                      <option value={1}>1 hour</option>
-                      <option value={4}>4 hours</option>
-                      <option value={8}>8 hours</option>
-                    </NativeSelect>
-                  </label>
-                  <Button type="button" className="col-span-2" disabled={!state.schedule.length || preparationMutation.isPending} onClick={() => setConfirmingPreparation(true)}>Prepare schedule</Button>
-                </div>
-              )}
+            <div className="max-w-2xl">
+              <Ident className="mb-2">TorBox</Ident>
+              <h2 id="preparation-heading" className="text-xl font-semibold tracking-[-0.01em]">Automatic Channel warm-up</h2>
+              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">Kids Channels automatically keeps the next 20 scheduled episodes ready in TorBox. When the Channel advances or its schedule changes, the new final episode is queued for preparation in the background.</p>
+              <p className="mt-3 text-sm leading-relaxed text-muted-foreground">Cached matches become ready immediately. When none are cached, TorBox downloads one exact-match source and Kids Channels keeps checking it.</p>
             </div>
 
             {preparation && (
               <div className="mt-5 border-t pt-4">
-                {preparationActive && <p className="mb-4 text-sm text-muted-foreground">Preparation is active in the background. You can keep using the Channel while it runs.</p>}
                 <div className="flex flex-wrap items-center gap-2">
                   <StateBadge current={preparationActive}>{preparationStatusLabel(preparation.status)}</StateBadge>
                   <span className="font-mono text-xs text-muted-foreground">{preparation.counts.ready}/{preparation.requestedCount} ready</span>
                   {preparation.counts.downloading > 0 && <span className="font-mono text-xs text-muted-foreground">{preparation.counts.downloading} downloading</span>}
                   {preparation.counts.trying + preparation.counts.queued > 0 && <span className="font-mono text-xs text-muted-foreground">{preparation.counts.trying + preparation.counts.queued} trying</span>}
                   {preparation.counts.unavailable > 0 && <span className="font-mono text-xs text-muted-foreground">{preparation.counts.unavailable} unavailable</span>}
-                  {preparationActive && <Button type="button" variant="outline" size="sm" className="ml-auto" disabled={preparationMutation.isPending} onClick={() => void changePreparation("cancel").catch(() => undefined)}>{preparationMutation.variables === "cancel" ? "Stopping…" : "Stop preparation"}</Button>}
                 </div>
                 {preparation.failureReason && <p className="mt-3 text-sm text-destructive">{preparation.failureReason}</p>}
                 <ol className="mt-4 grid gap-2" aria-label="Preparation progress">
@@ -222,8 +168,8 @@ function TvChannelPage() {
                 </ol>
               </div>
             )}
+            {!preparation && !preparationQuery.isError && <p className="mt-4 text-sm text-muted-foreground">Warm-up begins automatically when TorBox is connected and the TV Channel has scheduled episodes.</p>}
             {preparationQuery.isError && <p className="mt-4 text-sm text-destructive">Preparation status could not be loaded.</p>}
-            <p className={preparationFailed ? "mt-4 text-sm font-medium text-destructive" : "mt-4 text-sm font-medium text-accent"} role={preparationFailed ? "alert" : "status"} aria-live="polite">{preparationMessage}</p>
           </section>
 
           <section aria-labelledby="schedule-heading">
@@ -281,20 +227,12 @@ function TvChannelPage() {
       )}
 
       <ConfirmationDialog open={confirmingRegeneration} pending={mutation === "regenerate"} onOpenChange={setConfirmingRegeneration} onConfirm={() => performAction("regenerate")} />
-      <PreparationDialog
-        open={confirmingPreparation}
-        pending={preparationMutation.isPending}
-        count={Math.min(preparationCount, countLimit)}
-        hours={preparationHours}
-        onOpenChange={setConfirmingPreparation}
-        onConfirm={() => changePreparation("start")}
-      />
     </section>
   );
 }
 
 function preparationStatusLabel(status: PreparationStatus) {
-  return ({ queued: "Starting", running: "Preparing", completed: "Finished", cancelled: "Stopped", failed: "Failed" } as const)[status];
+  return ({ queued: "Starting", running: "Preparing", completed: "Up to date", cancelled: "Refreshing", failed: "Retry pending" } as const)[status];
 }
 
 function preparationItemLabel(status: PreparationItemStatus) {
@@ -322,23 +260,6 @@ function ConfirmationDialog({ open, pending, onOpenChange, onConfirm }: { open: 
         <DialogFooter>
           <Button type="button" variant="outline" disabled={pending} onClick={() => onOpenChange(false)}>Cancel</Button>
           <Button type="button" disabled={pending} onClick={() => { void onConfirm().then(() => onOpenChange(false)).catch(() => undefined); }}>{pending ? "Regenerating…" : "Regenerate selections"}</Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-function PreparationDialog({ open, pending, count, hours, onOpenChange, onConfirm }: { open: boolean; pending: boolean; count: number; hours: number; onOpenChange: (open: boolean) => void; onConfirm: () => Promise<void> }) {
-  return (
-    <Dialog modal={false} open={open} onOpenChange={(next) => { if (!pending) onOpenChange(next); }}>
-      <DialogContent className="data-closed:hidden" showCloseButton={false}>
-        <DialogHeader>
-          <DialogTitle>Prepare upcoming programmes?</DialogTitle>
-          <DialogDescription>For up to {hours} hour{hours === 1 ? "" : "s"}, Kids Channels will prepare {count} programme{count === 1 ? "" : "s"}. Cached matches become ready immediately; otherwise TorBox downloads one selected source and later rounds check its progress.</DialogDescription>
-        </DialogHeader>
-        <DialogFooter>
-          <Button type="button" variant="outline" disabled={pending} onClick={() => onOpenChange(false)}>Cancel</Button>
-          <Button type="button" disabled={pending} onClick={() => { void onConfirm().then(() => onOpenChange(false)).catch(() => undefined); }}>{pending ? "Starting…" : "Start preparation"}</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/tv-preparation.ts
+++ b/src/tv-preparation.ts
@@ -1,12 +1,15 @@
 import { WorkflowEntrypoint, type WorkflowEvent, type WorkflowStep } from "cloudflare:workers";
-import { loadTorBoxCredential } from "./torbox-credentials";
+import { loadTorBoxCredential, torBoxCredentialStatus } from "./torbox-credentials";
 import { selectCachedStream, type StreamSelectionEnv, type StreamSelectionOutcome } from "./stream-selection";
-import type { TvScheduledProgramme } from "./tv-channel";
+import { tvChannelSchedule, type TvScheduledProgramme } from "./tv-channel";
 
 const ROUND_INTERVAL = "5 minutes";
 const MAX_ROUNDS = 96;
 const ITEMS_PER_STEP = 5;
 const MAX_ITEM_BATCHES = 4;
+const AUTOMATIC_PREPARATION_COUNT = 20;
+const AUTOMATIC_PREPARATION_WINDOW_HOURS = 8;
+const AUTOMATIC_HOUSEHOLD_LIMIT = 100;
 
 export type TvPreparationRunStatus = "queued" | "running" | "completed" | "cancelled" | "failed";
 export type TvPreparationItemStatus = "queued" | "trying" | "downloading" | "ready" | "unavailable" | "cancelled";
@@ -96,6 +99,12 @@ export interface TvPreparationWorkflowParams {
 interface TvPreparationWorkflowEnv extends StreamSelectionEnv {
   DB: D1Database;
   CONFIG_SECRET?: string;
+}
+
+export interface AutomaticTvPreparationEnv extends TvPreparationWorkflowEnv {
+  TV_PREPARATION: Workflow<TvPreparationWorkflowParams>;
+  TV_SCHEDULE_SEED?: string;
+  AUTOMATIC_TV_PREPARATION_DISABLED?: string;
 }
 
 export async function createTvPreparationRun(
@@ -194,7 +203,12 @@ export async function tvPreparationRun(
   };
 }
 
-export async function cancelTvPreparationRun(db: D1Database, householdId: string, now = new Date()): Promise<TvPreparationRun | null> {
+export async function cancelTvPreparationRun(
+  db: D1Database,
+  householdId: string,
+  now = new Date(),
+  message = "Stopped by Parent",
+): Promise<TvPreparationRun | null> {
   const active = await db.prepare(`SELECT id FROM tv_preparation_runs
     WHERE household_id = ? AND status IN ('queued', 'running') ORDER BY created_at DESC LIMIT 1`)
     .bind(householdId).first<{ id: string }>();
@@ -203,10 +217,152 @@ export async function cancelTvPreparationRun(db: D1Database, householdId: string
   await db.batch([
     db.prepare(`UPDATE tv_preparation_runs SET status = 'cancelled', completed_at = ?, updated_at = ?
       WHERE id = ? AND status IN ('queued', 'running')`).bind(timestamp, timestamp, active.id),
-    db.prepare(`UPDATE tv_preparation_items SET status = 'cancelled', message = 'Stopped by Parent', updated_at = ?
-      WHERE run_id = ? AND status NOT IN ('ready', 'unavailable')`).bind(timestamp, active.id),
+    db.prepare(`UPDATE tv_preparation_items SET status = 'cancelled', message = ?, updated_at = ?
+      WHERE run_id = ? AND status NOT IN ('ready', 'unavailable')`).bind(message, timestamp, active.id),
   ]);
   return tvPreparationRun(db, householdId, active.id);
+}
+
+async function activeTvPreparationRun(db: D1Database, householdId: string): Promise<TvPreparationRun | null> {
+  const active = await db.prepare(`SELECT id FROM tv_preparation_runs
+    WHERE household_id = ? AND status IN ('queued', 'running') ORDER BY created_at DESC LIMIT 1`)
+    .bind(householdId).first<{ id: string }>();
+  return active ? tvPreparationRun(db, householdId, active.id) : null;
+}
+
+function snapshotMatches(run: TvPreparationRun, schedule: TvScheduledProgramme[]): boolean {
+  return run.items.length === schedule.length
+    && run.items.every((item, index) => item.videoId === schedule[index]?.episode.id);
+}
+
+async function scheduleIsHot(
+  db: D1Database,
+  householdId: string,
+  schedule: TvScheduledProgramme[],
+  now: Date,
+): Promise<boolean> {
+  if (!schedule.length) return true;
+  const placeholders = schedule.map(() => "?").join(", ");
+  const row = await db.prepare(`SELECT COUNT(DISTINCT video_id) AS count FROM stream_selections
+    WHERE household_id = ? AND content_type = 'series' AND download_pending = 0 AND stale_at > ?
+      AND video_id IN (${placeholders})`)
+    .bind(householdId, now.toISOString(), ...schedule.map((item) => item.episode.id))
+    .first<{ count: number }>();
+  return (row?.count ?? 0) === schedule.length;
+}
+
+async function terminateRun(env: AutomaticTvPreparationEnv, runId: string): Promise<void> {
+  if (env.AUTOMATIC_TV_PREPARATION_DISABLED === "true") return;
+  try { await (await env.TV_PREPARATION.get(runId)).terminate(); } catch { /* D1 status prevents further useful work */ }
+}
+
+export async function stopAutomaticTvPreparation(
+  env: AutomaticTvPreparationEnv,
+  householdId: string,
+  message: string,
+  now = new Date(),
+): Promise<void> {
+  const active = await activeTvPreparationRun(env.DB, householdId);
+  if (!active) return;
+  await cancelTvPreparationRun(env.DB, householdId, now, message);
+  await terminateRun(env, active.id);
+}
+
+export async function restartAutomaticTvPreparation(
+  env: AutomaticTvPreparationEnv,
+  householdId: string,
+  now = new Date(),
+): Promise<TvPreparationRun | null> {
+  await stopAutomaticTvPreparation(env, householdId, "Restarted after the TorBox connection changed", now);
+  return ensureAutomaticTvPreparation(env, householdId, undefined, now);
+}
+
+async function markRunFailed(db: D1Database, runId: string, reason: string, now = new Date()): Promise<void> {
+  const timestamp = now.toISOString();
+  await db.prepare(`UPDATE tv_preparation_runs
+    SET status = 'failed', failure_reason = ?, completed_at = ?, updated_at = ? WHERE id = ?`)
+    .bind(reason, timestamp, timestamp, runId).run();
+}
+
+export async function ensureAutomaticTvPreparation(
+  env: AutomaticTvPreparationEnv,
+  householdId: string,
+  suppliedSchedule?: TvScheduledProgramme[],
+  now = new Date(),
+): Promise<TvPreparationRun | null> {
+  if (!(await torBoxCredentialStatus(env.DB, householdId)).configured) return null;
+  const schedule = (suppliedSchedule ?? await tvChannelSchedule(env.DB, householdId, env.TV_SCHEDULE_SEED))
+    .slice(0, AUTOMATIC_PREPARATION_COUNT);
+  const active = await activeTvPreparationRun(env.DB, householdId);
+  if (active && snapshotMatches(active, schedule)) return active;
+  if (active) {
+    await cancelTvPreparationRun(env.DB, householdId, now, "Replaced by the latest Channel Schedule");
+    await terminateRun(env, active.id);
+  }
+  if (!schedule.length || await scheduleIsHot(env.DB, householdId, schedule, now)) return null;
+
+  let run: TvPreparationRun;
+  try {
+    run = await createTvPreparationRun(
+      env.DB,
+      householdId,
+      schedule,
+      AUTOMATIC_PREPARATION_COUNT,
+      AUTOMATIC_PREPARATION_WINDOW_HOURS,
+      now,
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message === "preparation already active") {
+      return activeTvPreparationRun(env.DB, householdId);
+    }
+    throw error;
+  }
+  try {
+    if (env.AUTOMATIC_TV_PREPARATION_DISABLED === "true") return run;
+    await env.TV_PREPARATION.create({
+      id: run.id,
+      params: { runId: run.id, householdId },
+      retention: { successRetention: "7 days", errorRetention: "7 days" },
+    });
+  } catch (error) {
+    await markRunFailed(env.DB, run.id, "Cloudflare could not start automatic Channel preparation.", now);
+    throw error;
+  }
+  return run;
+}
+
+export async function ensureAutomaticTvPreparationForAll(env: AutomaticTvPreparationEnv): Promise<void> {
+  const timestamp = new Date().toISOString();
+  const { results } = await env.DB.prepare(`SELECT household.id FROM households household
+    WHERE household.torbox_token_ciphertext IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM tv_preparation_runs run
+        WHERE run.household_id = household.id AND run.status IN ('queued', 'running')
+      )
+      AND EXISTS (
+        SELECT 1 FROM channel_schedule schedule
+        WHERE schedule.household_id = household.id AND schedule.channel = 'tv'
+          AND NOT EXISTS (
+            SELECT 1 FROM stream_selections selection
+            WHERE selection.household_id = household.id AND selection.content_type = 'series'
+              AND selection.video_id = schedule.video_id AND selection.download_pending = 0
+              AND selection.stale_at > ?
+          )
+      )
+    ORDER BY household.created_at LIMIT ?`)
+    .bind(timestamp, AUTOMATIC_HOUSEHOLD_LIMIT)
+    .all<{ id: string }>();
+  for (const household of results) {
+    try {
+      await ensureAutomaticTvPreparation(env, household.id);
+    } catch (error) {
+      console.error(JSON.stringify({
+        message: "automatic TV preparation reconciliation failed",
+        householdId: household.id,
+        reason: error instanceof Error ? error.message : "unknown error",
+      }));
+    }
+  }
 }
 
 async function processBatch(

--- a/test/browser/tv-channel.spec.ts
+++ b/test/browser/tv-channel.spec.ts
@@ -61,6 +61,9 @@ test("a Parent inspects and controls the TV Channel with progressive disclosure"
   await page.goto(`${parentUrl}/tv-channel`);
 
   await expect(page.getByRole("heading", { name: "TV Channel" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Automatic Channel warm-up" })).toBeVisible();
+  await expect(page.getByText("automatically keeps the next 20 scheduled episodes ready")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Prepare schedule" })).toBeHidden();
   const current = page.getByRole("heading", { name: "Current Programme" }).locator("..");
   await expect(current).toContainText("Green Adventures");
   await expect(current).toContainText("S01E01 — Episode 1");

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -2,7 +2,12 @@ import { env, SELF as worker } from "cloudflare:test";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { storeTorBoxCredential } from "../src/torbox-credentials";
 import { issueStreamToken } from "../src/secrets";
-import { cancelTvPreparationRun, createTvPreparationRun, tvPreparationRun } from "../src/tv-preparation";
+import {
+  cancelTvPreparationRun,
+  createTvPreparationRun,
+  ensureAutomaticTvPreparation,
+  tvPreparationRun,
+} from "../src/tv-preparation";
 import { requestTvProgramme, tvChannelSchedule } from "../src/tv-channel";
 
 const SELF = {
@@ -1108,19 +1113,36 @@ describe("rolling TV Channel Schedule", () => {
     expect((await tvPreparationRun(env.DB, created.householdId))?.items.every((item) => item.message === "Stopped by Parent")).toBe(true);
   });
 
-  it("protects Preparation Run status and validates manual start settings", async () => {
+  it("exposes automatic preparation status without a manual start endpoint", async () => {
     const { created } = await arrangeShows(1);
     const endpoint = `https://kids.test/api/households/${secretFrom(created)}/tv-preparation`;
     expect((await SELF.fetch(endpoint)).status).toBe(401);
     const headers = await parentHeaders(created);
-    const invalid = await SELF.fetch(endpoint, {
+    expect(await (await SELF.fetch(endpoint, { headers })).json()).toEqual({ run: null });
+    const manualStart = await SELF.fetch(endpoint, {
       method: "POST",
       headers: { ...headers, "content-type": "application/json" },
       body: JSON.stringify({ count: 21, windowHours: 8 }),
     });
-    expect(invalid.status).toBe(400);
-    expect(await invalid.json()).toEqual({ error: "Choose between 1 and 20 programmes." });
-    expect(await (await SELF.fetch(endpoint, { headers })).json()).toEqual({ run: null });
+    expect(manualStart.status).toBe(404);
+  });
+
+  it("automatically snapshots twenty programmes and replaces the run after the schedule advances", async () => {
+    const { created } = await arrangeShows(2);
+    await storeTorBoxCredential(env.DB, created.householdId, "household-torbox-token", env.CONFIG_SECRET);
+    const firstSchedule = await tvChannelSchedule(env.DB, created.householdId, "deterministic-test-seed");
+    const firstRun = await ensureAutomaticTvPreparation(env, created.householdId, firstSchedule, new Date("2026-08-01T10:00:00.000Z"));
+
+    expect(firstRun).toMatchObject({ status: "queued", requestedCount: 20 });
+    expect(firstRun?.items.map((item) => item.videoId)).toEqual(firstSchedule.map((item) => item.episode.id));
+
+    await requestTvProgramme(env.DB, created.householdId, firstSchedule[1].episode.id, "deterministic-test-seed");
+    const secondSchedule = await tvChannelSchedule(env.DB, created.householdId, "deterministic-test-seed");
+    const secondRun = await ensureAutomaticTvPreparation(env, created.householdId, secondSchedule, new Date("2026-08-01T10:01:00.000Z"));
+
+    expect(secondRun?.id).not.toBe(firstRun?.id);
+    expect(secondRun?.items.map((item) => item.videoId)).toEqual(secondSchedule.map((item) => item.episode.id));
+    expect(await tvPreparationRun(env.DB, created.householdId, firstRun!.id)).toMatchObject({ status: "cancelled" });
   });
 
   it("alternates eligible shows deterministically and inspects twenty programmes without advancing Show Progress", async () => {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -23,6 +23,9 @@
       "class_name": "TvSchedulePreparationWorkflow"
     }
   ],
+  "triggers": {
+    "crons": ["*/15 * * * *"]
+  },
   "observability": {
     "enabled": false
   },
@@ -47,7 +50,10 @@
           "name": "kids-channels-development-tv-preparation",
           "class_name": "TvSchedulePreparationWorkflow"
         }
-      ]
+      ],
+      "triggers": {
+        "crons": ["*/15 * * * *"]
+      }
     }
   }
 }

--- a/wrangler.test.jsonc
+++ b/wrangler.test.jsonc
@@ -10,7 +10,8 @@
   },
   "vars": {
     "CONFIG_SECRET": "test-only-configuration-secret-at-least-32-characters",
-    "TV_SCHEDULE_SEED": "deterministic-test-seed"
+    "TV_SCHEDULE_SEED": "deterministic-test-seed",
+    "AUTOMATIC_TV_PREPARATION_DISABLED": "true"
   },
   "d1_databases": [
     {


### PR DESCRIPTION
## Summary

- automatically keep up to twenty scheduled TV episodes ready in TorBox
- reconcile immediately after TorBox changes and every TV schedule mutation or playback advancement
- replace an active Workflow when its schedule snapshot changes while reusing valid selections and TorBox downloads
- run a fifteen-minute cron safety check for expired selections and missed triggers
- remove the Parent-facing start, count, duration, stop controls and their mutation endpoints
- retain the authenticated warm-up status view so Parents can see ready, downloading, and retrying episodes

## Behaviour

Connecting TorBox or creating/changing a TV schedule starts a bounded eight-hour Preparation Run automatically. The run covers the current twenty-item Channel Schedule. When playback advances, the changed snapshot replaces the old run and the newly appended final episode is prepared. Existing ready selections and in-progress TorBox downloads are reused.

Every fifteen minutes, a scheduled Worker event finds configured Households with no active run and at least one scheduled episode lacking a fresh ready selection. This restarts warm-up after selections expire or if an immediate trigger was missed.

## Verification

- `pnpm typecheck`
- `pnpm test` — production build, 60 Worker tests, 3 component tests
- `pnpm test:browser` — 28 Chromium tests
- `wrangler deploy --dry-run` — Workflow and cron configuration validated