### PR TITLE
fix: bound D1 reads and writes

### DIFF
--- a/src/movie-channel.ts
+++ b/src/movie-channel.ts
@@ -179,34 +179,32 @@ async function synchronizeRotation(db: D1Database, householdId: string): Promise
   for (let attempt = 0; attempt < MUTATION_ATTEMPTS; attempt += 1) {
     const currentState = await state(db, householdId);
     if (!currentState) return;
-    const [movies, existing, membership] = await Promise.all([
+    const [movies, membership] = await Promise.all([
       approvedMovies(db, householdId),
-      remainingRows(db, householdId, currentState),
-      db.prepare(`SELECT programme_id FROM movie_rotation WHERE household_id = ? AND cycle = ?`)
-        .bind(householdId, currentState.cycle).all<{ programme_id: string }>(),
+      db.prepare(`SELECT position, programme_id FROM movie_rotation WHERE household_id = ? AND cycle = ?`)
+        .bind(householdId, currentState.cycle).all<{ position: number; programme_id: string }>(),
     ]);
     const present = new Set(membership.results.map((movie) => movie.programme_id));
     const additions = movies.filter((movie) => !present.has(movie.programme_id));
     if (additions.length === 0) return;
 
-    const future: MovieRow[] = [...existing];
-    for (const movie of additions) {
-      const insertion = stableIndex(`${currentState.selection_seed}:${movie.programme_id}`,
-        currentState.cycle, currentState.revision, future.length + 1);
-      future.splice(insertion, 0, movie);
-    }
+    // Keep every existing coordinate stable: sign-off URLs embed cycle and position, and
+    // rewriting the complete tail makes sequential approvals quadratic. Newly approved
+    // movies join the end of this cycle in deterministic approval order, before any repeat.
+    const finalPosition = membership.results.reduce(
+      (maximum, movie) => Math.max(maximum, movie.position),
+      currentState.current_position,
+    );
     const owner = crypto.randomUUID();
     const now = new Date().toISOString();
     const owns = mutationOwnership(householdId, currentState.revision, owner);
     const statements: D1PreparedStatement[] = [
       claimMutation(db, householdId, currentState.revision, owner, now),
-      db.prepare(`DELETE FROM movie_rotation WHERE household_id = ? AND cycle = ? AND position > ? AND ${owns.sql}`)
-        .bind(householdId, currentState.cycle, currentState.current_position, ...owns.values),
     ];
-    for (const [offset, movie] of future.entries()) {
+    for (const [offset, movie] of additions.entries()) {
       statements.push(db.prepare(`INSERT INTO movie_rotation (household_id, cycle, position, programme_id)
         SELECT ?, ?, ?, ? WHERE ${owns.sql}`)
-        .bind(householdId, currentState.cycle, currentState.current_position + offset + 1,
+        .bind(householdId, currentState.cycle, finalPosition + offset + 1,
           movie.programme_id, ...owns.values));
     }
     statements.push(db.prepare(`UPDATE movie_channel_state SET revision = revision + 1

--- a/src/overview.ts
+++ b/src/overview.ts
@@ -1,5 +1,5 @@
 import { reconcileMovieChannel } from "./movie-channel";
-import { refreshTvChannelSchedule } from "./tv-channel";
+import { tvChannelSchedule } from "./tv-channel";
 
 export interface OverviewEpisode {
   id: string;
@@ -67,8 +67,8 @@ export async function householdOverview(
   tvSeed?: string,
   movieSeed?: string,
 ): Promise<HouseholdOverview> {
-  // Keep the same lazy Channel initialization behaviour as the detailed Channel APIs.
-  await refreshTvChannelSchedule(db, householdId, false, tvSeed);
+  // Keep lazy initialization, but do not rebuild valid Channel state during a read.
+  await tvChannelSchedule(db, householdId, tvSeed);
   await reconcileMovieChannel(db, householdId, movieSeed);
 
   const [counts, currentTv, nextTvRows, currentMovie] = await Promise.all([

--- a/src/routes/households.$secret.add-programmes.tsx
+++ b/src/routes/households.$secret.add-programmes.tsx
@@ -32,11 +32,28 @@ type SearchProgramme = {
   genres: string[];
   imdbRating?: string;
 };
-type ProgrammeSummary = { imdbId: string; type: ProgrammeType };
+type ProgrammeSummary = {
+  id: string;
+  imdbId: string;
+  type: ProgrammeType;
+  title: string;
+  poster?: string;
+  releaseInfo?: string;
+  genres: string[];
+  imdbRating?: string;
+  approvedAt: string;
+  pausedAt?: string;
+  current: boolean;
+  finished: boolean;
+  showProgress?: SelectableEpisode;
+};
 type SearchResponse = { results: SearchProgramme[] };
 type LibraryResponse = { programmes: ProgrammeSummary[] };
 type ShowDetailResponse = { title: SearchProgramme & { type: "show"; episodes: SelectableEpisode[] } };
 type ApprovalInput = { programme: SearchProgramme; startingEpisodeId?: string };
+type ApprovalResponse = {
+  programme: Omit<ProgrammeSummary, "current" | "finished">;
+};
 
 const PAGE_SIZE = 12;
 
@@ -95,33 +112,45 @@ function AddProgrammesPage() {
     retry: false,
   });
 
-  const approveProgramme = ({ programme, startingEpisodeId: selectedEpisode }: ApprovalInput) => parentApi<{ programme: unknown }>(`/api/households/${secret}/library`, {
+  const approveProgramme = ({ programme, startingEpisodeId: selectedEpisode }: ApprovalInput) => parentApi<ApprovalResponse>(`/api/households/${secret}/library`, {
     method: "POST",
     body: { type: programme.type, imdbId: programme.id, ...(selectedEpisode ? { startingEpisodeId: selectedEpisode } : {}) },
   });
-  const invalidateAfterApproval = () => Promise.all([
-    queryClient.invalidateQueries({ queryKey: parentKeys.library(secret) }),
-    queryClient.invalidateQueries({ queryKey: parentKeys.overview(secret) }),
-    queryClient.invalidateQueries({ queryKey: parentKeys.movie(secret) }),
-    queryClient.invalidateQueries({ queryKey: parentKeys.tv(secret) }),
-  ]);
+  const settleAfterApproval = (response: ApprovalResponse) => {
+    queryClient.setQueryData<LibraryResponse>(parentKeys.library(secret), (current) => {
+      if (!current || current.programmes.some((item) => item.id === response.programme.id)) return current;
+      const currentForType = current.programmes.some((item) => item.type === response.programme.type && item.current);
+      return {
+        programmes: [...current.programmes, {
+          ...response.programme,
+          current: !currentForType,
+          finished: false,
+        }],
+      };
+    });
+    return Promise.all([
+      queryClient.invalidateQueries({ queryKey: parentKeys.overview(secret), refetchType: "none" }),
+      queryClient.invalidateQueries({ queryKey: parentKeys.movie(secret), refetchType: "none" }),
+      queryClient.invalidateQueries({ queryKey: parentKeys.tv(secret), refetchType: "none" }),
+    ]);
+  };
 
   const approval = useMutation({
     mutationFn: approveProgramme,
-    onSuccess: async (_data, { programme }) => {
+    onSuccess: async (data, { programme }) => {
       window.dispatchEvent(new Event("stremio-restart-required"));
       toast.success(`“${programme.title}” added to the Approved Library.`);
       setDetail(null);
-      await invalidateAfterApproval();
+      await settleAfterApproval(data);
     },
   });
 
   const quickApproval = useMutation({
     mutationFn: approveProgramme,
-    onSuccess: async (_data, { programme }) => {
+    onSuccess: async (data, { programme }) => {
       window.dispatchEvent(new Event("stremio-restart-required"));
       toast.success(`“${programme.title}” added to the Approved Library.`);
-      await invalidateAfterApproval();
+      await settleAfterApproval(data);
     },
     onError: (error, { programme }) => {
       toast.error(apiErrorMessage(error, `“${programme.title}” could not be approved. Try again.`));

--- a/src/tv-channel.ts
+++ b/src/tv-channel.ts
@@ -122,17 +122,22 @@ async function loadShows(db: D1Database, householdId: string): Promise<Show[]> {
     WHERE programme.household_id = ? AND programme.content_type = 'show' AND programme.paused_at IS NULL
     ORDER BY programme.approved_at, programme.id`).bind(householdId).all<ShowRow>();
 
-  const episodeRows = await db.prepare(`SELECT episode.programme_id, episode.video_id, episode.season,
-      episode.episode, episode.title AS episode_title, episode.released_at, episode.overview
-    FROM show_episodes episode
-    JOIN approved_programmes programme ON programme.id = episode.programme_id
-    WHERE programme.household_id = ? AND programme.content_type = 'show'
-    ORDER BY episode.programme_id, episode.season, episode.episode`).bind(householdId).all<EpisodeRow>();
+  const episodeWindows = showRows.results.length === 0
+    ? []
+    : await db.batch<EpisodeRow>(showRows.results.map((row) => db.prepare(`SELECT episode.programme_id,
+        episode.video_id, episode.season, episode.episode, episode.title AS episode_title,
+        episode.released_at, episode.overview
+      FROM show_episodes episode
+      JOIN show_episodes progress
+        ON progress.programme_id = episode.programme_id AND progress.video_id = ?
+      WHERE episode.programme_id = ?
+        AND (episode.season, episode.episode) >= (progress.season, progress.episode)
+      ORDER BY episode.season, episode.episode
+      LIMIT ?`).bind(row.next_video_id, row.programme_id, TV_SCHEDULE_LENGTH)));
 
-  return showRows.results.flatMap((row) => {
-    const episodes = episodeRows.results.filter((episode) => episode.programme_id === row.programme_id).map(episodeFromRow);
-    const progressIndex = episodes.findIndex((episode) => episode.id === row.next_video_id);
-    return progressIndex < 0 ? [] : [{
+  return showRows.results.flatMap((row, index) => {
+    const episodes = (episodeWindows[index]?.results ?? []).map(episodeFromRow);
+    return episodes.length === 0 ? [] : [{
       programmeId: row.programme_id,
       imdbId: row.imdb_id,
       title: row.show_title,
@@ -140,7 +145,7 @@ async function loadShows(db: D1Database, householdId: string): Promise<Show[]> {
       poster: row.poster ?? undefined,
       background: row.background ?? undefined,
       episodes,
-      progressIndex,
+      progressIndex: 0,
     }];
   });
 }
@@ -415,10 +420,16 @@ export async function refreshTvChannelSchedule(
     WHERE household_id = ? AND channel = 'tv'`).bind(householdId)
     .first<{ programme_id: string; video_id: string }>();
   const currentShow = storedCurrent
-    ? shows.find((show) => show.programmeId === storedCurrent.programme_id
-      && show.episodes.some((episode) => episode.id === storedCurrent.video_id))
+    ? shows.find((show) => show.programmeId === storedCurrent.programme_id)
     : undefined;
-  const currentEpisode = currentShow?.episodes.find((episode) => episode.id === storedCurrent?.video_id);
+  let currentEpisode = currentShow?.episodes.find((episode) => episode.id === storedCurrent?.video_id);
+  if (currentShow && storedCurrent && !currentEpisode) {
+    const storedEpisode = await db.prepare(`SELECT programme_id, video_id, season, episode,
+        title AS episode_title, released_at, overview
+      FROM show_episodes WHERE programme_id = ? AND video_id = ?`)
+      .bind(storedCurrent.programme_id, storedCurrent.video_id).first<EpisodeRow>();
+    currentEpisode = storedEpisode ? episodeFromRow(storedEpisode) : undefined;
+  }
   const seed = regenerate ? crypto.randomUUID() : currentState.selection_seed;
   const position = currentState.current_position;
   const programmes: TvScheduledProgramme[] = currentShow && currentEpisode

--- a/test/browser/add-programmes.spec.ts
+++ b/test/browser/add-programmes.spec.ts
@@ -66,9 +66,18 @@ test("movie search state, details, pagination, and approval survive navigation",
 test("a movie can be approved in one click from the search results", async ({ page }) => {
   await page.route("https://placehold.co/**", (route) => route.abort());
   const parentUrl = await createHousehold(page);
+  let libraryReads = 0;
+  page.on("request", (request) => {
+    if (request.method() === "GET" && /\/api\/households\/[^/]+\/library$/.test(new URL(request.url()).pathname)) {
+      libraryReads += 1;
+    }
+  });
   await page.goto(`${parentUrl}/add-programmes?q=Example&type=movie&page=1`);
 
   const movie = page.getByRole("article").filter({ has: page.getByRole("heading", { name: "Example: The Movie" }) });
+  await expect(movie).toBeVisible();
+  const readsBeforeApproval = libraryReads;
+  expect(readsBeforeApproval).toBeGreaterThan(0);
   const approvalResponse = page.waitForResponse((response) => response.request().method() === "POST" && /\/api\/households\/[^/]+\/library$/.test(new URL(response.url()).pathname));
   await movie.getByRole("button", { name: "Approve Example: The Movie" }).click();
   expect((await approvalResponse).status()).toBe(201);
@@ -76,6 +85,8 @@ test("a movie can be approved in one click from the search results", async ({ pa
   await expect(page.locator("[data-sonner-toaster]")).toHaveCSS("position", "fixed");
   await expect(movie.getByText("Already approved")).toBeVisible();
   await expect(movie.getByRole("button", { name: "Approve Example: The Movie" })).toHaveCount(0);
+  await page.waitForTimeout(100);
+  expect(libraryReads).toBe(readsBeforeApproval);
 });
 
 test("a show can be approved from a non-default released episode without losing search context", async ({ page }) => {

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -1,6 +1,7 @@
 import { env, SELF as worker } from "cloudflare:test";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { storeTorBoxCredential } from "../src/torbox-credentials";
+import { reconcileMovieChannel } from "../src/movie-channel";
 import { issueStreamToken } from "../src/secrets";
 import {
   cancelTvPreparationRun,
@@ -8,7 +9,7 @@ import {
   ensureAutomaticTvPreparation,
   tvPreparationRun,
 } from "../src/tv-preparation";
-import { requestTvProgramme, tvChannelSchedule } from "../src/tv-channel";
+import { refreshTvChannelSchedule, requestTvProgramme, tvChannelSchedule } from "../src/tv-channel";
 
 const SELF = {
   fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
@@ -564,6 +565,24 @@ describe("Household Overview summary", () => {
     expect(summary.movie.current).toMatchObject({ title: "Overview Movie", releaseInfo: "2023" });
     expect(summary.tv.current).not.toHaveProperty("description");
     expect(summary.movie.current).not.toHaveProperty("signOffId");
+
+    const scheduleBefore = await env.DB.prepare(`SELECT position, programme_id, video_id, scheduled_at
+      FROM channel_schedule WHERE household_id = ? AND channel = 'tv' ORDER BY position`)
+      .bind(populated.householdId).all();
+    const currentBefore = await env.DB.prepare(`SELECT programme_id, video_id, selected_at
+      FROM current_programmes WHERE household_id = ? AND channel = 'tv'`)
+      .bind(populated.householdId).first();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const repeated = await SELF.fetch(`https://kids.test/api/households/${secretFrom(populated)}/overview`, {
+      headers: await access(populated),
+    });
+    expect(repeated.status).toBe(200);
+    expect((await env.DB.prepare(`SELECT position, programme_id, video_id, scheduled_at
+      FROM channel_schedule WHERE household_id = ? AND channel = 'tv' ORDER BY position`)
+      .bind(populated.householdId).all()).results).toEqual(scheduleBefore.results);
+    expect(await env.DB.prepare(`SELECT programme_id, video_id, selected_at
+      FROM current_programmes WHERE household_id = ? AND channel = 'tv'`)
+      .bind(populated.householdId).first()).toEqual(currentBefore);
 
     const isolatedSummary = await (await SELF.fetch(
       `https://kids.test/api/households/${secretFrom(isolated)}/overview`,
@@ -1171,6 +1190,36 @@ describe("rolling TV Channel Schedule", () => {
     );
   });
 
+  it("bounds episode catalogue queries to the persisted schedule length", async () => {
+    const { created } = await arrangeShows(1, 250);
+    await tvChannelSchedule(env.DB, created.householdId, "deterministic-test-seed");
+    const prepared: string[] = [];
+    const instrumented = new Proxy(env.DB, {
+      get(target, property) {
+        if (property === "prepare") {
+          return (query: string) => {
+            prepared.push(query);
+            return target.prepare(query);
+          };
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+
+    const schedule = await refreshTvChannelSchedule(
+      instrumented,
+      created.householdId,
+      false,
+      "deterministic-test-seed",
+    );
+
+    expect(schedule).toHaveLength(20);
+    const episodeQueries = prepared.filter((query) => query.includes("FROM show_episodes episode"));
+    expect(episodeQueries).toHaveLength(1);
+    expect(episodeQueries[0]).toContain("LIMIT ?");
+  });
+
   it("advances naturally or through Next exactly once and replenishes the shared schedule", async () => {
     const { base } = await arrangeShows(2);
     const before = await metadata(base);
@@ -1600,6 +1649,43 @@ describe("Movie Channel rotation and sign-off", () => {
       await SELF.fetch(current.meta.videos[1].streams[0].url);
     }
     expect(new Set(selected)).toEqual(new Set(["tt8000001", "tt8000002", "tt8000003"]));
+  });
+
+  it("adds one movie with bounded rotation mutations regardless of library size", async () => {
+    const { created } = await arrangeMovies(100);
+    await reconcileMovieChannel(env.DB, created.householdId, "bounded-rotation-seed");
+
+    const before = await env.DB.prepare(`SELECT position, programme_id FROM movie_rotation
+      WHERE household_id = ? AND cycle = 0 ORDER BY position`).bind(created.householdId)
+      .all<{ position: number; programme_id: string }>();
+    const now = new Date().toISOString();
+    await env.DB.prepare(`INSERT INTO approved_programmes
+      (id, household_id, imdb_id, content_type, title, genres_json, approved_at)
+      VALUES ('movie-101', ?, 'tt8000101', 'movie', 'Movie 101', '[]', ?)`).bind(created.householdId, now).run();
+
+    const mutations: string[] = [];
+    const instrumented = new Proxy(env.DB, {
+      get(target, property) {
+        if (property === "prepare") {
+          return (query: string) => {
+            if (/^(?:INSERT|UPDATE|DELETE)/.test(query.trim())) mutations.push(query.trim());
+            return target.prepare(query);
+          };
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+
+    await reconcileMovieChannel(instrumented, created.householdId, "bounded-rotation-seed");
+
+    expect(mutations).toHaveLength(3);
+    expect(mutations.some((query) => query.startsWith("DELETE FROM movie_rotation"))).toBe(false);
+    const after = await env.DB.prepare(`SELECT position, programme_id FROM movie_rotation
+      WHERE household_id = ? AND cycle = 0 ORDER BY position`).bind(created.householdId)
+      .all<{ position: number; programme_id: string }>();
+    expect(after.results.slice(0, before.results.length)).toEqual(before.results);
+    expect(after.results.at(-1)).toEqual({ position: 100, programme_id: "movie-101" });
   });
 
   it("shows the Current Programme, remaining rotation, and snapshot history only to the Parent", async () => {


### PR DESCRIPTION
## Summary

- make Movie Channel rotation synchronization incremental instead of deleting and reinserting the full future rotation
- keep Household Overview reads side-effect free after lazy schedule initialization
- bound TV schedule episode reads to a 20-episode window per active show, with an indexed exact lookup for an out-of-window current programme
- merge approved programmes into the client cache instead of immediately refetching the full library

## Measured impact

Production Query Insights attributed about 90% of recent D1 writes to Movie Channel rotation rewrites. The regression test for adding one movie to a 100-movie library records 3 prepared mutation statements after this change, compared with 103 before it.

The added regressions also verify that repeated Overview reads preserve schedule rows, TV schedule construction uses bounded episode queries, and approving a programme does not trigger another full-library GET.

## Verification

- pnpm typecheck
- pnpm test:all
  - 62 worker/unit tests
  - 3 component tests
  - 28 browser tests
- git diff --check

Closes #76
Closes #77
Closes #78
Closes #79