### PR TITLE
feat: share canonical show metadata across Households

### DIFF
--- a/migrations/0020_normalize_show_metadata.sql
+++ b/migrations/0020_normalize_show_metadata.sql
@@ -1,0 +1,141 @@
+PRAGMA defer_foreign_keys = on;
+
+CREATE TABLE canonical_shows (
+  imdb_id TEXT PRIMARY KEY NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT,
+  poster TEXT,
+  background TEXT,
+  release_info TEXT,
+  genres_json TEXT NOT NULL DEFAULT '[]',
+  imdb_rating TEXT
+);
+
+CREATE TABLE canonical_show_episodes (
+  show_imdb_id TEXT NOT NULL,
+  video_id TEXT NOT NULL,
+  season INTEGER NOT NULL,
+  episode INTEGER NOT NULL,
+  title TEXT NOT NULL,
+  released_at TEXT NOT NULL,
+  overview TEXT,
+  PRIMARY KEY (show_imdb_id, video_id),
+  FOREIGN KEY (show_imdb_id) REFERENCES canonical_shows(imdb_id) ON DELETE CASCADE,
+  UNIQUE (show_imdb_id, season, episode)
+);
+
+-- Prefer the most recently approved copy when historical Household snapshots differ.
+INSERT INTO canonical_shows
+  (imdb_id, title, description, poster, background, release_info, genres_json, imdb_rating)
+SELECT programme.imdb_id, programme.title, programme.description, programme.poster,
+  programme.background, programme.release_info, programme.genres_json, programme.imdb_rating
+FROM approved_programmes programme
+WHERE programme.content_type = 'show'
+  AND NOT EXISTS (
+    SELECT 1 FROM approved_programmes newer
+    WHERE newer.content_type = 'show' AND newer.imdb_id = programme.imdb_id
+      AND (newer.approved_at > programme.approved_at
+        OR (newer.approved_at = programme.approved_at AND newer.id > programme.id))
+  );
+
+INSERT OR IGNORE INTO canonical_show_episodes
+  (show_imdb_id, video_id, season, episode, title, released_at, overview)
+SELECT programme.imdb_id, episode.video_id, episode.season, episode.episode,
+  episode.title, episode.released_at, episode.overview
+FROM show_episodes episode
+JOIN approved_programmes programme ON programme.id = episode.programme_id
+WHERE programme.content_type = 'show'
+ORDER BY programme.approved_at DESC, programme.id DESC;
+
+DROP TABLE show_episodes;
+
+-- Preserve the old logical shape for callers and migrations while the physical rows are canonical.
+CREATE VIEW show_episodes AS
+SELECT programme.id AS programme_id, episode.video_id, episode.season, episode.episode,
+  episode.title, episode.released_at, episode.overview
+FROM approved_programmes programme
+JOIN canonical_show_episodes episode ON episode.show_imdb_id = programme.imdb_id
+WHERE programme.content_type = 'show';
+
+CREATE TRIGGER show_episodes_insert
+INSTEAD OF INSERT ON show_episodes
+BEGIN
+  INSERT INTO canonical_show_episodes
+    (show_imdb_id, video_id, season, episode, title, released_at, overview)
+  SELECT programme.imdb_id, NEW.video_id, NEW.season, NEW.episode,
+    NEW.title, NEW.released_at, NEW.overview
+  FROM approved_programmes programme
+  WHERE programme.id = NEW.programme_id AND programme.content_type = 'show'
+  ON CONFLICT(show_imdb_id, video_id) DO UPDATE SET
+    season = excluded.season,
+    episode = excluded.episode,
+    title = excluded.title,
+    released_at = excluded.released_at,
+    overview = excluded.overview
+  WHERE canonical_show_episodes.season IS NOT excluded.season
+    OR canonical_show_episodes.episode IS NOT excluded.episode
+    OR canonical_show_episodes.title IS NOT excluded.title
+    OR canonical_show_episodes.released_at IS NOT excluded.released_at
+    OR canonical_show_episodes.overview IS NOT excluded.overview;
+END;
+
+CREATE TRIGGER show_episodes_update
+INSTEAD OF UPDATE ON show_episodes
+BEGIN
+  UPDATE canonical_show_episodes SET
+    video_id = NEW.video_id,
+    season = NEW.season,
+    episode = NEW.episode,
+    title = NEW.title,
+    released_at = NEW.released_at,
+    overview = NEW.overview
+  WHERE show_imdb_id = (
+    SELECT imdb_id FROM approved_programmes
+    WHERE id = OLD.programme_id AND content_type = 'show'
+  ) AND video_id = OLD.video_id;
+END;
+
+-- Household removal must never delete shared canonical episode metadata.
+CREATE TRIGGER show_episodes_delete
+INSTEAD OF DELETE ON show_episodes
+BEGIN
+  SELECT 1;
+END;
+
+CREATE TRIGGER approved_show_metadata_insert
+AFTER INSERT ON approved_programmes
+WHEN NEW.content_type = 'show'
+BEGIN
+  INSERT INTO canonical_shows
+    (imdb_id, title, description, poster, background, release_info, genres_json, imdb_rating)
+  VALUES (NEW.imdb_id, NEW.title, NEW.description, NEW.poster, NEW.background,
+    NEW.release_info, NEW.genres_json, NEW.imdb_rating)
+  ON CONFLICT(imdb_id) DO UPDATE SET
+    title = excluded.title,
+    description = excluded.description,
+    poster = excluded.poster,
+    background = excluded.background,
+    release_info = excluded.release_info,
+    genres_json = excluded.genres_json,
+    imdb_rating = excluded.imdb_rating
+  WHERE canonical_shows.title IS NOT excluded.title
+    OR canonical_shows.description IS NOT excluded.description
+    OR canonical_shows.poster IS NOT excluded.poster
+    OR canonical_shows.background IS NOT excluded.background
+    OR canonical_shows.release_info IS NOT excluded.release_info
+    OR canonical_shows.genres_json IS NOT excluded.genres_json
+    OR canonical_shows.imdb_rating IS NOT excluded.imdb_rating;
+
+  UPDATE approved_programmes SET
+    title = '', description = NULL, poster = NULL, background = NULL,
+    release_info = NULL, genres_json = '[]', imdb_rating = NULL
+  WHERE id = NEW.id;
+END;
+
+-- Historical show snapshots are no longer authoritative after canonical rows exist.
+UPDATE approved_programmes SET
+  title = '', description = NULL, poster = NULL, background = NULL,
+  release_info = NULL, genres_json = '[]', imdb_rating = NULL
+WHERE content_type = 'show';
+
+PRAGMA defer_foreign_keys = off;

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
     "db:migrate:local": "wrangler d1 migrations apply kids-channels --local",
     "db:migrate:remote": "wrangler d1 migrations apply kids-channels --remote",
     "db:migrate:development": "wrangler d1 migrations apply DB --remote --env development",
-    "test": "pnpm build && vitest run && vitest run --config vitest.component.config.ts",
+    "test": "pnpm build && pnpm test:migrations && vitest run && vitest run --config vitest.component.config.ts",
     "test:watch": "vitest",
     "test:component": "vitest run --config vitest.component.config.ts",
     "test:browser": "playwright test",
+    "test:migrations": "node scripts/test-normalize-show-metadata-migration.mjs",
     "test:all": "pnpm test && pnpm test:browser",
     "typecheck": "tsc"
   },

--- a/scripts/test-normalize-show-metadata-migration.mjs
+++ b/scripts/test-normalize-show-metadata-migration.mjs
@@ -1,0 +1,70 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const root = resolve(import.meta.dirname, "..");
+const persistence = mkdtempSync(join(tmpdir(), "kids-channels-migration-"));
+const wrangler = resolve(root, "node_modules/.bin/wrangler");
+
+function execute(args, capture = false) {
+  return execFileSync(wrangler, ["d1", "execute", "kids-channels", "--local", "--persist-to", persistence, "--yes", ...args], {
+    cwd: root,
+    encoding: "utf8",
+    stdio: capture ? ["ignore", "pipe", "inherit"] : "ignore",
+  });
+}
+
+function query(sql) {
+  const output = execute(["--command", sql, "--json"], true);
+  const result = JSON.parse(output);
+  return result[0]?.results ?? [];
+}
+
+try {
+  const legacyMigrations = readdirSync(join(root, "migrations"))
+    .filter((name) => /^00(0[1-9]|1\d)_.*\.sql$/.test(name))
+    .sort();
+  for (const migration of legacyMigrations) {
+    execute(["--file", join(root, "migrations", migration)]);
+  }
+  execute(["--file", join(root, "test/fixtures/0019_duplicate_show_state.sql")]);
+  execute(["--file", join(root, "migrations/0020_normalize_show_metadata.sql")]);
+
+  const counts = query(`SELECT
+    (SELECT COUNT(*) FROM canonical_shows) AS canonical_shows,
+    (SELECT COUNT(*) FROM canonical_show_episodes) AS canonical_episodes,
+    (SELECT COUNT(*) FROM approved_programmes) AS approvals,
+    (SELECT COUNT(*) FROM show_episodes) AS logical_episodes`)[0];
+  if (counts?.canonical_shows !== 1 || counts.canonical_episodes !== 2
+    || counts.approvals !== 2 || counts.logical_episodes !== 4) {
+    throw new Error(`canonical migration counts were not preserved: ${JSON.stringify(counts)}`);
+  }
+
+  const state = query(`SELECT progress.programme_id, progress.next_video_id,
+      current.video_id AS current_video_id, schedule.video_id AS scheduled_video_id,
+      canonical.title AS show_title
+    FROM show_progress progress
+    JOIN approved_programmes programme ON programme.id = progress.programme_id
+    JOIN canonical_shows canonical ON canonical.imdb_id = programme.imdb_id
+    JOIN current_programmes current ON current.programme_id = programme.id AND current.channel = 'tv'
+    JOIN channel_schedule schedule ON schedule.programme_id = programme.id AND schedule.channel = 'tv'
+    ORDER BY progress.programme_id`);
+  const expected = [
+    { programme_id: "programme-a", next_video_id: "tt1234567:1:1", current_video_id: "tt1234567:1:1", scheduled_video_id: "tt1234567:1:1", show_title: "Example Show" },
+    { programme_id: "programme-b", next_video_id: "tt1234567:1:2", current_video_id: "tt1234567:1:2", scheduled_video_id: "tt1234567:1:2", show_title: "Example Show" },
+  ];
+  if (JSON.stringify(state) !== JSON.stringify(expected)) {
+    throw new Error(`Household Channel state was not preserved: ${JSON.stringify(state)}`);
+  }
+
+  const snapshots = query("SELECT title, description, poster, background, release_info, genres_json, imdb_rating FROM approved_programmes ORDER BY id");
+  if (snapshots.some((row) => row.title !== "" || row.description !== null || row.poster !== null
+    || row.background !== null || row.release_info !== null || row.genres_json !== "[]" || row.imdb_rating !== null)) {
+    throw new Error(`Household show metadata snapshots remain populated: ${JSON.stringify(snapshots)}`);
+  }
+
+  console.log("Show metadata normalization migration preserved two Household states and deduplicated canonical rows.");
+} finally {
+  rmSync(persistence, { recursive: true, force: true });
+}

--- a/src/approved-library.ts
+++ b/src/approved-library.ts
@@ -82,8 +82,18 @@ export async function approvedProgrammeDetail(
   householdId: string,
   programmeId: string,
 ): Promise<ApprovedProgramme | null> {
-  const row = await db.prepare(`SELECT p.*, progress.next_video_id
+  const row = await db.prepare(`SELECT p.id, p.imdb_id, p.content_type,
+      CASE WHEN p.content_type = 'show' THEN canonical.title ELSE p.title END AS title,
+      CASE WHEN p.content_type = 'show' THEN canonical.description ELSE p.description END AS description,
+      CASE WHEN p.content_type = 'show' THEN canonical.poster ELSE p.poster END AS poster,
+      CASE WHEN p.content_type = 'show' THEN canonical.background ELSE p.background END AS background,
+      CASE WHEN p.content_type = 'show' THEN canonical.release_info ELSE p.release_info END AS release_info,
+      CASE WHEN p.content_type = 'show' THEN canonical.genres_json ELSE p.genres_json END AS genres_json,
+      CASE WHEN p.content_type = 'show' THEN canonical.imdb_rating ELSE p.imdb_rating END AS imdb_rating,
+      p.approved_at, p.paused_at, progress.next_video_id
     FROM approved_programmes p
+    LEFT JOIN canonical_shows canonical
+      ON p.content_type = 'show' AND canonical.imdb_id = p.imdb_id
     LEFT JOIN show_progress progress ON progress.programme_id = p.id
     WHERE p.id = ? AND p.household_id = ?`).bind(programmeId, householdId)
     .first<StoredProgramme & { next_video_id: string | null }>();
@@ -160,19 +170,29 @@ type SummaryRow = StoredProgramme & {
 /** A compact Parent Page projection. Episode catalogues are deliberately loaded only by
  * the programme-detail endpoint; this list includes at most the single Show Progress episode. */
 export async function approvedLibrary(db: D1Database, householdId: string): Promise<ApprovedProgrammeSummary[]> {
-  const rows = await db.prepare(`SELECT p.*,
+  const rows = await db.prepare(`SELECT p.id, p.imdb_id, p.content_type,
+      CASE WHEN p.content_type = 'show' THEN canonical.title ELSE p.title END AS title,
+      CASE WHEN p.content_type = 'show' THEN canonical.description ELSE p.description END AS description,
+      CASE WHEN p.content_type = 'show' THEN canonical.poster ELSE p.poster END AS poster,
+      CASE WHEN p.content_type = 'show' THEN canonical.background ELSE p.background END AS background,
+      CASE WHEN p.content_type = 'show' THEN canonical.release_info ELSE p.release_info END AS release_info,
+      CASE WHEN p.content_type = 'show' THEN canonical.genres_json ELSE p.genres_json END AS genres_json,
+      CASE WHEN p.content_type = 'show' THEN canonical.imdb_rating ELSE p.imdb_rating END AS imdb_rating,
+      p.approved_at, p.paused_at,
       CASE WHEN current.programme_id IS NULL THEN 0 ELSE 1 END AS is_current,
       progress.next_video_id AS progress_video_id,
       episode.season AS progress_season, episode.episode AS progress_episode,
       episode.title AS progress_title, episode.released_at AS progress_released_at
     FROM approved_programmes p
+    LEFT JOIN canonical_shows canonical
+      ON p.content_type = 'show' AND canonical.imdb_id = p.imdb_id
     LEFT JOIN current_programmes current
       ON current.household_id = p.household_id AND current.programme_id = p.id
     LEFT JOIN show_progress progress ON progress.programme_id = p.id
     LEFT JOIN show_episodes episode
       ON episode.programme_id = p.id AND episode.video_id = progress.next_video_id
     WHERE p.household_id = ?
-    ORDER BY p.approved_at, p.title`).bind(householdId).all<SummaryRow>();
+    ORDER BY p.approved_at, title`).bind(householdId).all<SummaryRow>();
 
   return rows.results.map((row) => {
     const programme = programmeFromRow(row);

--- a/src/households.ts
+++ b/src/households.ts
@@ -169,7 +169,6 @@ export async function deleteHousehold(db: D1Database, householdId: string): Prom
     db.prepare("DELETE FROM channel_state WHERE household_id = ?").bind(householdId),
     db.prepare("DELETE FROM current_programmes WHERE household_id = ?").bind(householdId),
     db.prepare(`DELETE FROM show_progress WHERE programme_id IN (${approved})`).bind(householdId),
-    db.prepare(`DELETE FROM show_episodes WHERE programme_id IN (${approved})`).bind(householdId),
     db.prepare("DELETE FROM approved_programmes WHERE household_id = ?").bind(householdId),
     db.prepare("DELETE FROM pin_attempts WHERE household_id = ?").bind(householdId),
     db.prepare("DELETE FROM households WHERE id = ?").bind(householdId),

--- a/src/index.ts
+++ b/src/index.ts
@@ -516,7 +516,6 @@ export default {
           env.DB.prepare("DELETE FROM channel_schedule WHERE household_id = ? AND programme_id = ?").bind(household.id, programme.id),
           env.DB.prepare("DELETE FROM current_programmes WHERE household_id = ? AND programme_id = ?").bind(household.id, programme.id),
           env.DB.prepare("DELETE FROM show_progress WHERE programme_id = ?").bind(programme.id),
-          env.DB.prepare("DELETE FROM show_episodes WHERE programme_id = ?").bind(programme.id),
           env.DB.prepare("DELETE FROM approved_programmes WHERE id = ? AND household_id = ?").bind(programme.id, household.id),
         ]);
         await refreshTvChannelSchedule(env.DB, household.id, false, env.TV_SCHEDULE_SEED);

--- a/src/overview.ts
+++ b/src/overview.ts
@@ -76,17 +76,19 @@ export async function householdOverview(
       SUM(CASE WHEN content_type = 'show' THEN 1 ELSE 0 END) AS shows,
       SUM(CASE WHEN content_type = 'movie' THEN 1 ELSE 0 END) AS movies
       FROM approved_programmes WHERE household_id = ?`).bind(householdId).first<CountRow>(),
-    db.prepare(`SELECT programme.id AS programme_id, programme.title, programme.poster,
+    db.prepare(`SELECT programme.id AS programme_id, canonical.title, canonical.poster,
         episode.video_id, episode.season, episode.episode, episode.title AS episode_title
       FROM current_programmes current
       JOIN approved_programmes programme ON programme.id = current.programme_id AND programme.household_id = current.household_id
+      JOIN canonical_shows canonical ON canonical.imdb_id = programme.imdb_id
       JOIN show_episodes episode ON episode.programme_id = current.programme_id AND episode.video_id = current.video_id
       WHERE current.household_id = ? AND current.channel = 'tv'`).bind(householdId).first<TvRow>(),
-    db.prepare(`SELECT programme.id AS programme_id, programme.title, programme.poster,
+    db.prepare(`SELECT programme.id AS programme_id, canonical.title, canonical.poster,
         episode.video_id, episode.season, episode.episode, episode.title AS episode_title
       FROM channel_schedule schedule
       JOIN channel_state state ON state.household_id = schedule.household_id AND state.channel = schedule.channel
       JOIN approved_programmes programme ON programme.id = schedule.programme_id AND programme.household_id = schedule.household_id
+      JOIN canonical_shows canonical ON canonical.imdb_id = programme.imdb_id
       JOIN show_episodes episode ON episode.programme_id = schedule.programme_id AND episode.video_id = schedule.video_id
       WHERE schedule.household_id = ? AND schedule.channel = 'tv' AND schedule.position > state.current_position
       ORDER BY schedule.position

--- a/src/stream-selection.ts
+++ b/src/stream-selection.ts
@@ -156,8 +156,10 @@ async function canonicalProgramme(
     } : null;
   }
 
-  const row = await db.prepare(`SELECT p.id, p.imdb_id, p.title, p.release_info, e.season, e.episode
+  const row = await db.prepare(`SELECT p.id, p.imdb_id, canonical.title, canonical.release_info,
+      e.season, e.episode
     FROM approved_programmes p
+    JOIN canonical_shows canonical ON canonical.imdb_id = p.imdb_id
     JOIN show_episodes e ON e.programme_id = p.id
     WHERE p.household_id = ? AND p.content_type = 'show' AND e.video_id = ?`)
     .bind(householdId, videoId)

--- a/src/tv-channel.ts
+++ b/src/tv-channel.ts
@@ -115,9 +115,10 @@ function programmeFromRow(row: ScheduleRow): TvScheduledProgramme {
 
 async function loadShows(db: D1Database, householdId: string): Promise<Show[]> {
   const showRows = await db.prepare(`SELECT programme.id AS programme_id, programme.imdb_id,
-      programme.title AS show_title, programme.description, programme.poster, programme.background,
+      canonical.title AS show_title, canonical.description, canonical.poster, canonical.background,
       progress.next_video_id
     FROM approved_programmes programme
+    JOIN canonical_shows canonical ON canonical.imdb_id = programme.imdb_id
     JOIN show_progress progress ON progress.programme_id = programme.id
     WHERE programme.household_id = ? AND programme.content_type = 'show' AND programme.paused_at IS NULL
     ORDER BY programme.approved_at, programme.id`).bind(householdId).all<ShowRow>();
@@ -236,11 +237,12 @@ async function releaseExpiredUnavailableEpisodes(
 
 async function scheduleRows(db: D1Database, householdId: string): Promise<TvScheduledProgramme[]> {
   const rows = await db.prepare(`SELECT schedule.position, schedule.programme_id, programme.imdb_id,
-      programme.title AS show_title, programme.description, programme.poster, programme.background,
+      canonical.title AS show_title, canonical.description, canonical.poster, canonical.background,
       episode.video_id, episode.season, episode.episode, episode.title AS episode_title,
       episode.released_at, episode.overview
     FROM channel_schedule schedule
     JOIN approved_programmes programme ON programme.id = schedule.programme_id
+    JOIN canonical_shows canonical ON canonical.imdb_id = programme.imdb_id
     JOIN show_episodes episode ON episode.programme_id = schedule.programme_id AND episode.video_id = schedule.video_id
     JOIN channel_state state ON state.household_id = schedule.household_id AND state.channel = schedule.channel
     WHERE schedule.household_id = ? AND schedule.channel = 'tv' AND schedule.position >= state.current_position
@@ -484,11 +486,12 @@ export async function parentTvChannelState(
   configuredSeed?: string,
 ): Promise<ParentTvChannelState> {
   const schedule = await tvChannelSchedule(db, householdId, configuredSeed);
-  const history = await db.prepare(`SELECT programme.title AS show_title,
+  const history = await db.prepare(`SELECT canonical.title AS show_title,
       episode.video_id, episode.season, episode.episode, episode.title, episode.released_at, episode.overview,
       history.advanced_at
     FROM tv_advancement_history history
     JOIN approved_programmes programme ON programme.id = history.previous_programme_id
+    JOIN canonical_shows canonical ON canonical.imdb_id = programme.imdb_id
     JOIN show_episodes episode ON episode.programme_id = history.previous_programme_id
       AND episode.video_id = history.previous_video_id
     WHERE history.household_id = ?

--- a/test/fixtures/0019_duplicate_show_state.sql
+++ b/test/fixtures/0019_duplicate_show_state.sql
@@ -1,0 +1,45 @@
+INSERT INTO households (id, secret, pin_salt, pin_hash, created_at)
+VALUES
+  ('household-a', 'secret-a', 'salt', 'hash', '2026-01-01T00:00:00.000Z'),
+  ('household-b', 'secret-b', 'salt', 'hash', '2026-01-02T00:00:00.000Z');
+
+INSERT INTO approved_programmes
+  (id, household_id, imdb_id, content_type, title, description, poster, background,
+   release_info, genres_json, imdb_rating, approved_at, paused_at)
+VALUES
+  ('programme-a', 'household-a', 'tt1234567', 'show', 'Example Show', 'Description',
+   'poster', 'background', '2020', '["Family"]', '8.0', '2026-01-01T00:00:00.000Z', NULL),
+  ('programme-b', 'household-b', 'tt1234567', 'show', 'Example Show', 'Description',
+   'poster', 'background', '2020', '["Family"]', '8.0', '2026-01-02T00:00:00.000Z', NULL);
+
+INSERT INTO show_episodes
+  (programme_id, video_id, season, episode, title, released_at, overview)
+VALUES
+  ('programme-a', 'tt1234567:1:1', 1, 1, 'First', '2020-01-01T00:00:00.000Z', 'First overview'),
+  ('programme-a', 'tt1234567:1:2', 1, 2, 'Second', '2020-01-08T00:00:00.000Z', 'Second overview'),
+  ('programme-b', 'tt1234567:1:1', 1, 1, 'First', '2020-01-01T00:00:00.000Z', 'First overview'),
+  ('programme-b', 'tt1234567:1:2', 1, 2, 'Second', '2020-01-08T00:00:00.000Z', 'Second overview');
+
+INSERT INTO show_progress (programme_id, next_video_id)
+VALUES
+  ('programme-a', 'tt1234567:1:1'),
+  ('programme-b', 'tt1234567:1:2');
+
+INSERT INTO current_programmes
+  (household_id, channel, programme_id, video_id, selected_at)
+VALUES
+  ('household-a', 'tv', 'programme-a', 'tt1234567:1:1', '2026-01-03T00:00:00.000Z'),
+  ('household-b', 'tv', 'programme-b', 'tt1234567:1:2', '2026-01-03T00:00:00.000Z');
+
+INSERT INTO channel_state
+  (household_id, channel, current_position, selection_seed, initialized_at)
+VALUES
+  ('household-a', 'tv', 0, 'seed-a', '2026-01-03T00:00:00.000Z'),
+  ('household-b', 'tv', 0, 'seed-b', '2026-01-03T00:00:00.000Z');
+
+INSERT INTO channel_schedule
+  (household_id, channel, position, programme_id, video_id, scheduled_at)
+VALUES
+  ('household-a', 'tv', 0, 'programme-a', 'tt1234567:1:1', '2026-01-03T00:00:00.000Z'),
+  ('household-b', 'tv', 0, 'programme-b', 'tt1234567:1:2', '2026-01-03T00:00:00.000Z');
+

--- a/test/stream-selection.test.ts
+++ b/test/stream-selection.test.ts
@@ -46,14 +46,47 @@ beforeEach(async () => {
   )`).run();
   await env.DB.prepare(`CREATE TABLE IF NOT EXISTS approved_programmes (
     id TEXT PRIMARY KEY NOT NULL, household_id TEXT NOT NULL, imdb_id TEXT NOT NULL,
-    content_type TEXT NOT NULL, title TEXT NOT NULL, release_info TEXT,
-    genres_json TEXT NOT NULL DEFAULT '[]', approved_at TEXT NOT NULL
+    content_type TEXT NOT NULL, title TEXT NOT NULL, description TEXT, poster TEXT, background TEXT,
+    release_info TEXT, genres_json TEXT NOT NULL DEFAULT '[]', imdb_rating TEXT, approved_at TEXT NOT NULL
   )`).run();
-  await env.DB.prepare(`CREATE TABLE IF NOT EXISTS show_episodes (
-    programme_id TEXT NOT NULL, video_id TEXT NOT NULL, season INTEGER NOT NULL,
-    episode INTEGER NOT NULL, title TEXT NOT NULL, released_at TEXT NOT NULL,
-    PRIMARY KEY (programme_id, video_id)
+  await env.DB.prepare(`CREATE TABLE IF NOT EXISTS canonical_shows (
+    imdb_id TEXT PRIMARY KEY NOT NULL, title TEXT NOT NULL, description TEXT, poster TEXT,
+    background TEXT, release_info TEXT, genres_json TEXT NOT NULL DEFAULT '[]', imdb_rating TEXT
   )`).run();
+  await env.DB.prepare(`CREATE TABLE IF NOT EXISTS canonical_show_episodes (
+    show_imdb_id TEXT NOT NULL, video_id TEXT NOT NULL, season INTEGER NOT NULL,
+    episode INTEGER NOT NULL, title TEXT NOT NULL, released_at TEXT NOT NULL, overview TEXT,
+    PRIMARY KEY (show_imdb_id, video_id)
+  )`).run();
+  await env.DB.prepare(`CREATE VIEW IF NOT EXISTS show_episodes AS
+    SELECT programme.id AS programme_id, episode.video_id, episode.season, episode.episode,
+      episode.title, episode.released_at, episode.overview
+    FROM approved_programmes programme
+    JOIN canonical_show_episodes episode ON episode.show_imdb_id = programme.imdb_id
+    WHERE programme.content_type = 'show'`).run();
+  await env.DB.prepare(`CREATE TRIGGER IF NOT EXISTS approved_show_metadata_insert
+    AFTER INSERT ON approved_programmes WHEN NEW.content_type = 'show' BEGIN
+      INSERT INTO canonical_shows
+        (imdb_id, title, description, poster, background, release_info, genres_json, imdb_rating)
+      VALUES (NEW.imdb_id, NEW.title, NEW.description, NEW.poster, NEW.background,
+        NEW.release_info, NEW.genres_json, NEW.imdb_rating)
+      ON CONFLICT(imdb_id) DO UPDATE SET title = excluded.title, description = excluded.description,
+        poster = excluded.poster, background = excluded.background, release_info = excluded.release_info,
+        genres_json = excluded.genres_json, imdb_rating = excluded.imdb_rating;
+      UPDATE approved_programmes SET title = '', description = NULL, poster = NULL, background = NULL,
+        release_info = NULL, genres_json = '[]', imdb_rating = NULL WHERE id = NEW.id;
+    END`).run();
+  await env.DB.prepare(`CREATE TRIGGER IF NOT EXISTS show_episodes_insert
+    INSTEAD OF INSERT ON show_episodes BEGIN
+      INSERT INTO canonical_show_episodes
+        (show_imdb_id, video_id, season, episode, title, released_at, overview)
+      SELECT programme.imdb_id, NEW.video_id, NEW.season, NEW.episode,
+        NEW.title, NEW.released_at, NEW.overview
+      FROM approved_programmes programme WHERE programme.id = NEW.programme_id
+      ON CONFLICT(show_imdb_id, video_id) DO UPDATE SET season = excluded.season,
+        episode = excluded.episode, title = excluded.title, released_at = excluded.released_at,
+        overview = excluded.overview;
+    END`).run();
   await env.DB.prepare(`CREATE TABLE IF NOT EXISTS stream_selections (
     household_id TEXT NOT NULL, programme_id TEXT NOT NULL, content_type TEXT NOT NULL,
     video_id TEXT NOT NULL, torrent_id TEXT NOT NULL, info_hash TEXT NOT NULL,
@@ -70,8 +103,9 @@ beforeEach(async () => {
   )`).run();
   await env.DB.prepare("DELETE FROM stream_candidate_failures").run();
   await env.DB.prepare("DELETE FROM stream_selections").run();
-  await env.DB.prepare("DELETE FROM show_episodes").run();
   await env.DB.prepare("DELETE FROM approved_programmes").run();
+  await env.DB.prepare("DELETE FROM canonical_show_episodes").run();
+  await env.DB.prepare("DELETE FROM canonical_shows").run();
   await env.DB.prepare("DELETE FROM households").run();
   await env.DB.prepare(`INSERT INTO households (id, secret, pin_salt, pin_hash, created_at)
     VALUES ('household', 'secret', 'salt', 'hash', 'now')`).run();

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { storeTorBoxCredential } from "../src/torbox-credentials";
 import { reconcileMovieChannel } from "../src/movie-channel";
 import { issueStreamToken } from "../src/secrets";
+import { deleteHousehold } from "../src/households";
 import {
   cancelTvPreparationRun,
   createTvPreparationRun,
@@ -57,11 +58,53 @@ beforeEach(async () => {
     release_info TEXT, genres_json TEXT NOT NULL DEFAULT '[]', imdb_rating TEXT, approved_at TEXT NOT NULL,
     paused_at TEXT, UNIQUE (household_id, content_type, imdb_id)
   )`).run();
-  await env.DB.prepare(`CREATE TABLE IF NOT EXISTS show_episodes (
-    programme_id TEXT NOT NULL, video_id TEXT NOT NULL, season INTEGER NOT NULL, episode INTEGER NOT NULL,
-    title TEXT NOT NULL, released_at TEXT NOT NULL, overview TEXT,
-    PRIMARY KEY (programme_id, video_id), UNIQUE (programme_id, season, episode)
+  await env.DB.prepare(`CREATE TABLE IF NOT EXISTS canonical_shows (
+    imdb_id TEXT PRIMARY KEY NOT NULL, title TEXT NOT NULL, description TEXT, poster TEXT,
+    background TEXT, release_info TEXT, genres_json TEXT NOT NULL DEFAULT '[]', imdb_rating TEXT
   )`).run();
+  await env.DB.prepare(`CREATE TABLE IF NOT EXISTS canonical_show_episodes (
+    show_imdb_id TEXT NOT NULL, video_id TEXT NOT NULL, season INTEGER NOT NULL, episode INTEGER NOT NULL,
+    title TEXT NOT NULL, released_at TEXT NOT NULL, overview TEXT,
+    PRIMARY KEY (show_imdb_id, video_id), UNIQUE (show_imdb_id, season, episode)
+  )`).run();
+  await env.DB.prepare(`CREATE VIEW IF NOT EXISTS show_episodes AS
+    SELECT programme.id AS programme_id, episode.video_id, episode.season, episode.episode,
+      episode.title, episode.released_at, episode.overview
+    FROM approved_programmes programme
+    JOIN canonical_show_episodes episode ON episode.show_imdb_id = programme.imdb_id
+    WHERE programme.content_type = 'show'`).run();
+  await env.DB.prepare(`CREATE TRIGGER IF NOT EXISTS approved_show_metadata_insert
+    AFTER INSERT ON approved_programmes WHEN NEW.content_type = 'show' BEGIN
+      INSERT INTO canonical_shows
+        (imdb_id, title, description, poster, background, release_info, genres_json, imdb_rating)
+      VALUES (NEW.imdb_id, NEW.title, NEW.description, NEW.poster, NEW.background,
+        NEW.release_info, NEW.genres_json, NEW.imdb_rating)
+      ON CONFLICT(imdb_id) DO UPDATE SET title = excluded.title, description = excluded.description,
+        poster = excluded.poster, background = excluded.background, release_info = excluded.release_info,
+        genres_json = excluded.genres_json, imdb_rating = excluded.imdb_rating;
+      UPDATE approved_programmes SET title = '', description = NULL, poster = NULL, background = NULL,
+        release_info = NULL, genres_json = '[]', imdb_rating = NULL WHERE id = NEW.id;
+    END`).run();
+  await env.DB.prepare(`CREATE TRIGGER IF NOT EXISTS show_episodes_insert
+    INSTEAD OF INSERT ON show_episodes BEGIN
+      INSERT INTO canonical_show_episodes
+        (show_imdb_id, video_id, season, episode, title, released_at, overview)
+      SELECT programme.imdb_id, NEW.video_id, NEW.season, NEW.episode,
+        NEW.title, NEW.released_at, NEW.overview
+      FROM approved_programmes programme WHERE programme.id = NEW.programme_id
+      ON CONFLICT(show_imdb_id, video_id) DO UPDATE SET season = excluded.season,
+        episode = excluded.episode, title = excluded.title, released_at = excluded.released_at,
+        overview = excluded.overview;
+    END`).run();
+  await env.DB.prepare(`CREATE TRIGGER IF NOT EXISTS show_episodes_update
+    INSTEAD OF UPDATE ON show_episodes BEGIN
+      UPDATE canonical_show_episodes SET video_id = NEW.video_id, season = NEW.season,
+        episode = NEW.episode, title = NEW.title, released_at = NEW.released_at, overview = NEW.overview
+      WHERE show_imdb_id = (SELECT imdb_id FROM approved_programmes WHERE id = OLD.programme_id)
+        AND video_id = OLD.video_id;
+    END`).run();
+  await env.DB.prepare(`CREATE TRIGGER IF NOT EXISTS show_episodes_delete
+    INSTEAD OF DELETE ON show_episodes BEGIN SELECT 1; END`).run();
   await env.DB.prepare(`CREATE TABLE IF NOT EXISTS show_progress (
     programme_id TEXT PRIMARY KEY NOT NULL, next_video_id TEXT NOT NULL
   )`).run();
@@ -164,8 +207,9 @@ beforeEach(async () => {
   await env.DB.prepare("DELETE FROM channel_state").run();
   await env.DB.prepare("DELETE FROM current_programmes").run();
   await env.DB.prepare("DELETE FROM show_progress").run();
-  await env.DB.prepare("DELETE FROM show_episodes").run();
   await env.DB.prepare("DELETE FROM approved_programmes").run();
+  await env.DB.prepare("DELETE FROM canonical_show_episodes").run();
+  await env.DB.prepare("DELETE FROM canonical_shows").run();
   await env.DB.prepare("DELETE FROM households").run();
   vi.restoreAllMocks();
 });
@@ -687,6 +731,65 @@ describe("Cinemeta Approved Library", () => {
     expect(library.programmes[0]).not.toHaveProperty("description");
     expect(library.programmes[0]).not.toHaveProperty("background");
     expect(JSON.stringify(library.programmes[0])).not.toContain("Second");
+  });
+
+  it("shares canonical show metadata across Households and preserves it when one Household is deleted", async () => {
+    const first = await create();
+    const second = await create();
+    const firstHeaders = await parentAccess(first);
+    const secondHeaders = await parentAccess(second);
+    mockCinemeta();
+
+    const firstApproval = await SELF.fetch(`https://kids.test/api/households/${secretFrom(first)}/library`, {
+      method: "POST",
+      headers: { ...firstHeaders, "content-type": "application/json" },
+      body: JSON.stringify({ type: "show", imdbId: "tt1234567" }),
+    });
+    const secondApproval = await SELF.fetch(`https://kids.test/api/households/${secretFrom(second)}/library`, {
+      method: "POST",
+      headers: { ...secondHeaders, "content-type": "application/json" },
+      body: JSON.stringify({ type: "show", imdbId: "tt1234567", startingEpisodeId: "tt1234567:1:2" }),
+    });
+    expect(firstApproval.status).toBe(201);
+    expect(secondApproval.status).toBe(201);
+    const secondProgrammeId = (await secondApproval.json<any>()).programme.id as string;
+
+    expect(await env.DB.prepare("SELECT COUNT(*) AS count FROM canonical_shows").first()).toMatchObject({ count: 1 });
+    expect(await env.DB.prepare("SELECT COUNT(*) AS count FROM canonical_show_episodes").first()).toMatchObject({ count: 2 });
+    expect(await env.DB.prepare("SELECT COUNT(*) AS count FROM approved_programmes").first()).toMatchObject({ count: 2 });
+    expect(await env.DB.prepare("SELECT COUNT(*) AS count FROM show_episodes").first()).toMatchObject({ count: 4 });
+
+    await tvChannelSchedule(env.DB, first.householdId, "first-household-seed");
+    const secondSchedule = await tvChannelSchedule(env.DB, second.householdId, "second-household-seed");
+    expect(secondSchedule[0]).toMatchObject({
+      programmeId: secondProgrammeId,
+      showTitle: "The Example",
+      episode: { id: "tt1234567:1:2", title: "Second" },
+    });
+
+    await deleteHousehold(env.DB, first.householdId);
+
+    expect(await env.DB.prepare("SELECT COUNT(*) AS count FROM canonical_shows").first()).toMatchObject({ count: 1 });
+    expect(await env.DB.prepare("SELECT COUNT(*) AS count FROM canonical_show_episodes").first()).toMatchObject({ count: 2 });
+    expect(await env.DB.prepare("SELECT COUNT(*) AS count FROM approved_programmes").first()).toMatchObject({ count: 1 });
+    const detail = await SELF.fetch(
+      `https://kids.test/api/households/${secretFrom(second)}/library/${secondProgrammeId}`,
+      { headers: secondHeaders },
+    );
+    expect(detail.status).toBe(200);
+    expect(await detail.json<any>()).toMatchObject({
+      programme: {
+        id: secondProgrammeId,
+        title: "The Example",
+        showProgress: { id: "tt1234567:1:2" },
+        episodes: [
+          { id: "tt1234567:1:1", title: "First" },
+          { id: "tt1234567:1:2", title: "Second" },
+        ],
+      },
+    });
+    expect(await tvChannelSchedule(env.DB, second.householdId, "second-household-seed"))
+      .toEqual(secondSchedule);
   });
 
   it("loads an approved show's stored episode detail without consulting current Cinemeta metadata", async () => {


### PR DESCRIPTION
## Summary

- add one canonical physical catalogue for Cinemeta show and episode metadata
- retain Household-owned approval IDs, Show Progress, Current Programmes, Channel Schedules, playback history, and stream-selection references
- expose the former show_episodes shape as a compatibility view backed by canonical rows
- preserve independent Household state and prevent Household/show deletion from removing shared metadata
- read canonical metadata throughout Approved Library, Overview, TV Channel, and stream resolution

## Migration safety

Migration 0020 chooses the newest historical show snapshot, deduplicates episode rows by canonical IMDb/video identity, preserves all Household-owned identifiers, and scrubs the former per-Household show snapshots. D1 foreign-key checks are deferred only for the migration transaction, following Cloudflare guidance.

An automated local-D1 migration test starts at schema 0019 with two Households that approved the same show, then verifies after migration:

- 1 physical canonical show and 2 physical episode rows
- 2 Household approvals and 4 logical episode projections
- exact Show Progress, Current Programme, and Channel Schedule references
- removal of duplicated Household metadata snapshots

## Verification

- pnpm typecheck
- pnpm test
  - local D1 migration preservation test
  - 63 worker/unit tests
  - 3 component tests
- pnpm test:browser
  - 28 browser tests
- git diff --check

Closes #80