### PR TITLE
feat: prune obsolete Channel coordination and history state

### DIFF
--- a/docs/channel-state-retention.md
+++ b/docs/channel-state-retention.md
@@ -1,0 +1,23 @@
+# Channel state retention
+
+The fifteen-minute scheduled Worker event sweeps at most 90 Households at a time. This stays below
+the D1 limit of 100 bound parameters after timestamp and row-cap parameters are included. A persisted
+cursor walks the Household primary key, wraps after the final Household, and caps each table at
+500 deleted rows per sweep. Cleanup therefore does not scan every Household during a request and
+large backlogs drain over repeated scheduled events.
+
+| State | Retention rule | Safety reason |
+| --- | --- | --- |
+| TV advancement claims | 24 hours; always keep the claim for the latest undoable advancement | Protects in-flight/stale requests and the supported undo action |
+| Movie advancement claims | 24 hours | Requests complete in seconds; the grace period protects in-flight work |
+| Movie mutation claims | 24 hours | Ownership is needed only by an active mutation batch |
+| TV playback/advancement history | Latest 10 per Household, plus the latest undoable advancement | The Parent Page displays 10 and undo must remain available |
+| Movie playback history | Latest 10 per Household | The Parent Page displays 10 snapshot titles |
+| Movie rotations | Current cycle only | Playback history snapshots retain the visible historical information |
+| TV Preparation Runs | Latest 10 per Household; never delete queued/running runs | Preserves recent operational context and active Workflow state |
+| Stream selections | Until `stale_at` | Expired selections cannot be used for playback |
+| Stream candidate failures | Until `retry_at` | Expired quarantines must no longer suppress a candidate |
+| Unavailable Episodes | Until `retry_at` | Expired deferrals must no longer block scheduling |
+
+Every non-empty sweep logs structured per-table deletion counts. Failures are logged independently
+from automatic TV preparation so one scheduled maintenance task cannot prevent the other.

--- a/migrations/0021_add_channel_retention_cursor.sql
+++ b/migrations/0021_add_channel_retention_cursor.sql
@@ -1,0 +1,5 @@
+CREATE TABLE maintenance_cursors (
+  name TEXT PRIMARY KEY NOT NULL,
+  last_household_id TEXT,
+  updated_at TEXT NOT NULL
+);

--- a/scripts/test-normalize-show-metadata-migration.mjs
+++ b/scripts/test-normalize-show-metadata-migration.mjs
@@ -30,6 +30,7 @@ try {
   }
   execute(["--file", join(root, "test/fixtures/0019_duplicate_show_state.sql")]);
   execute(["--file", join(root, "migrations/0020_normalize_show_metadata.sql")]);
+  execute(["--file", join(root, "migrations/0021_add_channel_retention_cursor.sql")]);
 
   const counts = query(`SELECT
     (SELECT COUNT(*) FROM canonical_shows) AS canonical_shows,
@@ -64,7 +65,12 @@ try {
     throw new Error(`Household show metadata snapshots remain populated: ${JSON.stringify(snapshots)}`);
   }
 
-  console.log("Show metadata normalization migration preserved two Household states and deduplicated canonical rows.");
+  const retentionCursor = query("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'maintenance_cursors'");
+  if (retentionCursor[0]?.name !== "maintenance_cursors") {
+    throw new Error("Channel retention cursor migration was not applied");
+  }
+
+  console.log("D1 migrations preserved Household state, deduplicated canonical rows, and installed retention state.");
 } finally {
   rmSync(persistence, { recursive: true, force: true });
 }

--- a/src/channel-retention.ts
+++ b/src/channel-retention.ts
@@ -1,0 +1,133 @@
+export const CHANNEL_RETENTION = {
+  claimHours: 24,
+  playbackHistoryPerHousehold: 10,
+  preparationRunsPerHousehold: 10,
+  // D1 permits 100 bound parameters per statement; reserve ten for cutoffs and limits.
+  householdsPerSweep: 90,
+  rowsPerTablePerSweep: 500,
+} as const;
+
+const CURSOR_NAME = "channel-retention";
+
+export interface ChannelRetentionResult {
+  households: number;
+  wrapped: boolean;
+  deleted: Record<string, number>;
+}
+
+function placeholders(count: number): string {
+  return Array.from({ length: count }, () => "?").join(", ");
+}
+
+export async function pruneObsoleteChannelState(
+  db: D1Database,
+  now = new Date(),
+  householdLimit: number = CHANNEL_RETENTION.householdsPerSweep,
+  rowLimit: number = CHANNEL_RETENTION.rowsPerTablePerSweep,
+): Promise<ChannelRetentionResult> {
+  const cursor = await db.prepare("SELECT last_household_id FROM maintenance_cursors WHERE name = ?")
+    .bind(CURSOR_NAME).first<{ last_household_id: string | null }>();
+  const households = await db.prepare(`SELECT id FROM households
+    WHERE (? IS NULL OR id > ?) ORDER BY id LIMIT ?`)
+    .bind(cursor?.last_household_id ?? null, cursor?.last_household_id ?? null, householdLimit)
+    .all<{ id: string }>();
+
+  if (households.results.length === 0) {
+    const timestamp = now.toISOString();
+    await db.prepare(`INSERT INTO maintenance_cursors (name, last_household_id, updated_at)
+      VALUES (?, NULL, ?) ON CONFLICT(name) DO UPDATE SET last_household_id = NULL, updated_at = excluded.updated_at`)
+      .bind(CURSOR_NAME, timestamp).run();
+    return { households: 0, wrapped: Boolean(cursor?.last_household_id), deleted: {} };
+  }
+
+  const householdIds = households.results.map((household) => household.id);
+  const householdSql = placeholders(householdIds.length);
+  const cutoff = new Date(now.getTime() - CHANNEL_RETENTION.claimHours * 60 * 60 * 1000).toISOString();
+  const timestamp = now.toISOString();
+  const statements = [
+    db.prepare(`DELETE FROM channel_advancements WHERE rowid IN (
+      SELECT claim.rowid FROM channel_advancements claim
+      WHERE claim.household_id IN (${householdSql}) AND claim.advanced_at < ?
+        AND NOT EXISTS (
+          SELECT 1 FROM tv_advancement_history history
+          JOIN channel_state state ON state.household_id = history.household_id AND state.channel = 'tv'
+          WHERE history.household_id = claim.household_id AND history.from_position = claim.from_position
+            AND history.id = claim.owner_token AND history.undone_at IS NULL
+            AND history.target_position = state.current_position
+        )
+      LIMIT ?
+    )`).bind(...householdIds, cutoff, rowLimit),
+    db.prepare(`DELETE FROM movie_advancements WHERE rowid IN (
+      SELECT rowid FROM movie_advancements
+      WHERE household_id IN (${householdSql}) AND advanced_at < ? LIMIT ?
+    )`).bind(...householdIds, cutoff, rowLimit),
+    db.prepare(`DELETE FROM movie_channel_mutations WHERE rowid IN (
+      SELECT rowid FROM movie_channel_mutations
+      WHERE household_id IN (${householdSql}) AND claimed_at < ? LIMIT ?
+    )`).bind(...householdIds, cutoff, rowLimit),
+    db.prepare(`DELETE FROM tv_advancement_history WHERE id IN (
+      SELECT id FROM (
+        SELECT id, household_id, target_position, undone_at,
+          ROW_NUMBER() OVER (PARTITION BY household_id ORDER BY advanced_at DESC, id DESC) AS history_rank
+        FROM tv_advancement_history WHERE household_id IN (${householdSql})
+      ) old
+      WHERE old.history_rank > ? AND NOT EXISTS (
+        SELECT 1 FROM channel_state state
+        WHERE state.household_id = old.household_id AND state.channel = 'tv'
+          AND old.undone_at IS NULL AND old.target_position = state.current_position
+      ) LIMIT ?
+    )`).bind(...householdIds, CHANNEL_RETENTION.playbackHistoryPerHousehold, rowLimit),
+    db.prepare(`DELETE FROM movie_playback_history WHERE id IN (
+      SELECT id FROM (
+        SELECT id, ROW_NUMBER() OVER (
+          PARTITION BY household_id ORDER BY played_at DESC, id DESC
+        ) AS history_rank
+        FROM movie_playback_history WHERE household_id IN (${householdSql})
+      ) old WHERE old.history_rank > ? LIMIT ?
+    )`).bind(...householdIds, CHANNEL_RETENTION.playbackHistoryPerHousehold, rowLimit),
+    db.prepare(`DELETE FROM movie_rotation WHERE rowid IN (
+      SELECT rotation.rowid FROM movie_rotation rotation
+      JOIN movie_channel_state state ON state.household_id = rotation.household_id
+      WHERE rotation.household_id IN (${householdSql}) AND rotation.cycle < state.cycle LIMIT ?
+    )`).bind(...householdIds, rowLimit),
+    db.prepare(`DELETE FROM tv_preparation_runs WHERE id IN (
+      SELECT id FROM (
+        SELECT id, status, ROW_NUMBER() OVER (
+          PARTITION BY household_id ORDER BY created_at DESC, id DESC
+        ) AS run_rank
+        FROM tv_preparation_runs WHERE household_id IN (${householdSql})
+      ) old WHERE old.run_rank > ? AND old.status NOT IN ('queued', 'running') LIMIT ?
+    )`).bind(...householdIds, CHANNEL_RETENTION.preparationRunsPerHousehold, rowLimit),
+    db.prepare(`DELETE FROM stream_selections WHERE rowid IN (
+      SELECT rowid FROM stream_selections
+      WHERE household_id IN (${householdSql}) AND stale_at <= ? LIMIT ?
+    )`).bind(...householdIds, timestamp, rowLimit),
+    db.prepare(`DELETE FROM stream_candidate_failures WHERE rowid IN (
+      SELECT rowid FROM stream_candidate_failures
+      WHERE household_id IN (${householdSql}) AND retry_at <= ? LIMIT ?
+    )`).bind(...householdIds, timestamp, rowLimit),
+    db.prepare(`DELETE FROM unavailable_episodes WHERE rowid IN (
+      SELECT rowid FROM unavailable_episodes
+      WHERE household_id IN (${householdSql}) AND retry_at <= ? LIMIT ?
+    )`).bind(...householdIds, timestamp, rowLimit),
+  ];
+  const tables = [
+    "channel_advancements",
+    "movie_advancements",
+    "movie_channel_mutations",
+    "tv_advancement_history",
+    "movie_playback_history",
+    "movie_rotation",
+    "tv_preparation_runs",
+    "stream_selections",
+    "stream_candidate_failures",
+    "unavailable_episodes",
+  ];
+  const results = await db.batch(statements);
+  const deleted = Object.fromEntries(results.map((result, index) => [tables[index], result.meta.changes]));
+  await db.prepare(`INSERT INTO maintenance_cursors (name, last_household_id, updated_at)
+    VALUES (?, ?, ?) ON CONFLICT(name) DO UPDATE SET
+      last_household_id = excluded.last_household_id, updated_at = excluded.updated_at`)
+    .bind(CURSOR_NAME, householdIds.at(-1), timestamp).run();
+  return { households: householdIds.length, wrapped: false, deleted };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ import {
   tvChannelSchedule,
   undoLatestTvAdvancement,
 } from "./tv-channel";
+import { pruneObsoleteChannelState } from "./channel-retention";
 
 export interface Env {
   DB: D1Database;
@@ -858,6 +859,20 @@ export default {
     return json({ error: "Not found." }, 404);
   },
   async scheduled(_controller: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
-    ctx.waitUntil(ensureAutomaticTvPreparationForAll(env));
+    ctx.waitUntil(ensureAutomaticTvPreparationForAll(env).catch((error) => {
+      console.error(JSON.stringify({
+        message: "automatic TV preparation sweep failed",
+        reason: error instanceof Error ? error.message : "unknown error",
+      }));
+    }));
+    ctx.waitUntil(pruneObsoleteChannelState(env.DB).then((result) => {
+      const totalDeleted = Object.values(result.deleted).reduce((total, count) => total + count, 0);
+      if (totalDeleted > 0) console.log(JSON.stringify({ message: "obsolete Channel state pruned", ...result }));
+    }).catch((error) => {
+      console.error(JSON.stringify({
+        message: "obsolete Channel state cleanup failed",
+        reason: error instanceof Error ? error.message : "unknown error",
+      }));
+    }));
   },
 } satisfies ExportedHandler<Env>;

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -4,6 +4,7 @@ import { storeTorBoxCredential } from "../src/torbox-credentials";
 import { reconcileMovieChannel } from "../src/movie-channel";
 import { issueStreamToken } from "../src/secrets";
 import { deleteHousehold } from "../src/households";
+import { CHANNEL_RETENTION, pruneObsoleteChannelState } from "../src/channel-retention";
 import {
   cancelTvPreparationRun,
   createTvPreparationRun,
@@ -189,8 +190,12 @@ beforeEach(async () => {
     status TEXT NOT NULL, attempts INTEGER NOT NULL DEFAULT 0, quality TEXT, filename TEXT, info_hash TEXT,
     message TEXT, updated_at TEXT NOT NULL, PRIMARY KEY (run_id, position)
   )`).run();
+  await env.DB.prepare(`CREATE TABLE IF NOT EXISTS maintenance_cursors (
+    name TEXT PRIMARY KEY NOT NULL, last_household_id TEXT, updated_at TEXT NOT NULL
+  )`).run();
   await env.DB.prepare("CREATE INDEX IF NOT EXISTS households_secret_idx ON households (secret)").run();
   await env.DB.prepare("DELETE FROM pin_attempts").run();
+  await env.DB.prepare("DELETE FROM maintenance_cursors").run();
   await env.DB.prepare("DELETE FROM tv_preparation_items").run();
   await env.DB.prepare("DELETE FROM tv_preparation_runs").run();
   await env.DB.prepare("DELETE FROM unavailable_episodes").run();
@@ -2000,6 +2005,116 @@ describe("Household deletion", () => {
       expect(body).not.toContain(unknownSecret);
       expect(body).not.toMatch(/PIN|Approved Library|Channel Schedule/);
     }
+  });
+});
+
+describe("scheduled Channel state retention", () => {
+  it("prunes bounded expired state while preserving active ownership, undo, and Parent history", async () => {
+    const now = new Date("2026-08-09T12:00:00.000Z");
+    const expired = "2026-08-07T12:00:00.000Z";
+    const active = "2026-08-09T11:00:00.000Z";
+    await env.DB.batch([
+      env.DB.prepare(`INSERT INTO households (id, secret, pin_salt, pin_hash, created_at)
+        VALUES ('retention-a', 'retention-secret-a', 'salt', 'hash', ?)`),
+      env.DB.prepare(`INSERT INTO households (id, secret, pin_salt, pin_hash, created_at)
+        VALUES ('retention-b', 'retention-secret-b', 'salt', 'hash', ?)`),
+    ].map((statement) => statement.bind(now.toISOString())));
+    await env.DB.prepare("INSERT INTO channel_state VALUES ('retention-a', 'tv', 99, 'seed', ?)")
+      .bind(expired).run();
+    await env.DB.prepare("INSERT INTO movie_channel_state VALUES ('retention-a', 2, 0, 'seed', ?, 0)")
+      .bind(expired).run();
+
+    const statements: D1PreparedStatement[] = [
+      env.DB.prepare("INSERT INTO channel_advancements VALUES ('retention-a', 'tv', 1, 2, 'expired-tv-claim', ?)").bind(expired),
+      env.DB.prepare("INSERT INTO channel_advancements VALUES ('retention-a', 'tv', 2, 3, 'active-tv-claim', ?)").bind(active),
+      env.DB.prepare("INSERT INTO channel_advancements VALUES ('retention-a', 'tv', 98, 99, 'undo-history', ?)").bind(expired),
+      env.DB.prepare("INSERT INTO movie_advancements VALUES ('retention-a', 0, 0, 'expired-movie-claim', ?)").bind(expired),
+      env.DB.prepare("INSERT INTO movie_advancements VALUES ('retention-a', 2, 0, 'active-movie-claim', ?)").bind(active),
+      env.DB.prepare("INSERT INTO movie_channel_mutations VALUES ('retention-a', 0, 'expired-mutation', ?)").bind(expired),
+      env.DB.prepare("INSERT INTO movie_channel_mutations VALUES ('retention-a', 1, 'active-mutation', ?)").bind(active),
+      env.DB.prepare("INSERT INTO movie_channel_mutations VALUES ('retention-b', 0, 'other-household-expired', ?)").bind(expired),
+      env.DB.prepare("INSERT INTO tv_advancement_history VALUES ('undo-history', 'retention-a', 98, 99, 'show', 'episode-98', 'show', 'episode-99', '{}', '{}', ?, NULL, NULL)").bind("2026-07-01T00:00:00.000Z"),
+      env.DB.prepare("INSERT INTO movie_rotation VALUES ('retention-a', 0, 0, 'movie-old-0', ?)").bind(expired),
+      env.DB.prepare("INSERT INTO movie_rotation VALUES ('retention-a', 1, 0, 'movie-old-1', ?)").bind(expired),
+      env.DB.prepare("INSERT INTO movie_rotation VALUES ('retention-a', 2, 0, 'movie-current', NULL)"),
+      env.DB.prepare(`INSERT INTO stream_selections
+        (household_id, programme_id, content_type, video_id, torrent_id, info_hash, file_id, filename,
+         quality, seeders, selected_at, stale_at, download_pending, last_progress)
+        VALUES ('retention-a', 'show', 'series', 'expired-stream', '1', ?, 1, 'expired.mkv', '1080p', 1, ?, ?, 0, 100)`)
+        .bind("a".repeat(40), expired, expired),
+      env.DB.prepare(`INSERT INTO stream_selections
+        (household_id, programme_id, content_type, video_id, torrent_id, info_hash, file_id, filename,
+         quality, seeders, selected_at, stale_at, download_pending, last_progress)
+        VALUES ('retention-a', 'show', 'series', 'active-stream', '2', ?, 2, 'active.mkv', '1080p', 1, ?, ?, 0, 100)`)
+        .bind("b".repeat(40), active, "2026-08-10T12:00:00.000Z"),
+      env.DB.prepare(`INSERT INTO stream_candidate_failures
+        VALUES ('retention-a', 'show', 'series', 'episode', ?, 'failed', ?, ?)`)
+        .bind("c".repeat(40), expired, expired),
+      env.DB.prepare(`INSERT INTO stream_candidate_failures
+        VALUES ('retention-a', 'show', 'series', 'episode', ?, 'failed', ?, ?)`)
+        .bind("d".repeat(40), active, "2026-08-10T12:00:00.000Z"),
+      env.DB.prepare("INSERT INTO unavailable_episodes VALUES ('retention-a', 'show', 'expired-episode', ?, ?)")
+        .bind(expired, expired),
+      env.DB.prepare("INSERT INTO unavailable_episodes VALUES ('retention-a', 'show', 'active-episode', ?, ?)")
+        .bind(active, "2026-08-10T12:00:00.000Z"),
+    ];
+    for (let index = 0; index < 11; index += 1) {
+      const timestamp = new Date(Date.UTC(2026, 7, 1, 0, index)).toISOString();
+      statements.push(env.DB.prepare(`INSERT INTO tv_advancement_history VALUES
+        (?, 'retention-a', ?, ?, 'show', ?, 'show', ?, '{}', '{}', ?, NULL, NULL)`)
+        .bind(`tv-history-${index}`, index, index + 1, `episode-${index}`, `episode-${index + 1}`, timestamp));
+      statements.push(env.DB.prepare(`INSERT INTO movie_playback_history VALUES
+        (?, 'retention-a', 'movie', 'tt1234567', 'Movie', 0, ?, ?)`)
+        .bind(`movie-history-${index}`, index, timestamp));
+    }
+    for (let index = 0; index < 12; index += 1) {
+      const timestamp = new Date(Date.UTC(2026, 7, 1, 1, index)).toISOString();
+      statements.push(env.DB.prepare(`INSERT INTO tv_preparation_runs
+        (id, household_id, status, requested_count, deadline_at, completed_at, created_at, updated_at)
+        VALUES (?, 'retention-a', 'completed', 1, ?, ?, ?, ?)`)
+        .bind(`run-${index}`, timestamp, timestamp, timestamp, timestamp));
+    }
+    statements.push(env.DB.prepare(`INSERT INTO tv_preparation_runs
+      (id, household_id, status, requested_count, deadline_at, created_at, updated_at)
+      VALUES ('active-run', 'retention-a', 'running', 1, ?, ?, ?)`)
+      .bind(expired, "2026-07-01T00:00:00.000Z", active));
+    await env.DB.batch(statements);
+
+    const first = await pruneObsoleteChannelState(env.DB, now, 1, 500);
+    expect(first.households).toBe(1);
+    expect(first.deleted).toMatchObject({
+      channel_advancements: 1,
+      movie_advancements: 1,
+      movie_channel_mutations: 1,
+      tv_advancement_history: 1,
+      movie_playback_history: 1,
+      movie_rotation: 2,
+      tv_preparation_runs: 2,
+      stream_selections: 1,
+      stream_candidate_failures: 1,
+      unavailable_episodes: 1,
+    });
+    expect(await env.DB.prepare("SELECT owner_token FROM channel_advancements ORDER BY from_position")
+      .all<{ owner_token: string }>()).toMatchObject({
+      results: [{ owner_token: "active-tv-claim" }, { owner_token: "undo-history" }],
+    });
+    expect(await env.DB.prepare("SELECT COUNT(*) AS count FROM tv_advancement_history").first())
+      .toMatchObject({ count: CHANNEL_RETENTION.playbackHistoryPerHousehold + 1 });
+    expect(await env.DB.prepare("SELECT COUNT(*) AS count FROM movie_playback_history").first())
+      .toMatchObject({ count: CHANNEL_RETENTION.playbackHistoryPerHousehold });
+    expect(await env.DB.prepare("SELECT COUNT(*) AS count FROM tv_preparation_runs").first())
+      .toMatchObject({ count: CHANNEL_RETENTION.preparationRunsPerHousehold + 1 });
+    expect(await env.DB.prepare("SELECT COUNT(*) AS count FROM movie_rotation").first()).toMatchObject({ count: 1 });
+    expect(await env.DB.prepare("SELECT COUNT(*) AS count FROM movie_channel_mutations WHERE household_id = 'retention-b'").first())
+      .toMatchObject({ count: 1 });
+
+    const second = await pruneObsoleteChannelState(env.DB, now, 1, 500);
+    expect(second.households).toBe(1);
+    expect(second.deleted.movie_channel_mutations).toBe(1);
+    const wrapped = await pruneObsoleteChannelState(env.DB, now, 1, 500);
+    expect(wrapped).toMatchObject({ households: 0, wrapped: true, deleted: {} });
+    const repeated = await pruneObsoleteChannelState(env.DB, now, 1, 500);
+    expect(Object.values(repeated.deleted).every((count) => count === 0)).toBe(true);
   });
 });
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -27,7 +27,8 @@
     "crons": ["*/15 * * * *"]
   },
   "observability": {
-    "enabled": false
+    "enabled": true,
+    "head_sampling_rate": 1
   },
   "env": {
     "development": {


### PR DESCRIPTION
## Summary

- run Channel-state cleanup from the existing fifteen-minute scheduled event, independently from automatic TV preparation
- sweep at most 90 Households through a persisted primary-key cursor and cap each table at 500 deletions per invocation
- retain claims for 24 hours and always preserve the claim/history pair for the latest undoable TV advancement
- retain the ten playback-history entries shown by each Parent Page Channel
- remove old Movie Channel cycles, terminal Preparation Runs beyond recent history, expired stream state, candidate quarantines, and Unavailable Episode deferrals
- enable persisted Workers Logs and emit structured per-table deletion counts and isolated task failures
- document every retention rule and its concurrency/history safety rationale

## Platform bounds

The 90-Household limit intentionally stays below D1s current 100-bound-parameter maximum after cutoff and row-limit parameters are included. Cleanup uses D1 bindings in tracked waitUntil tasks, and a Wrangler production dry run succeeds.

## Verification

- pnpm typecheck
- pnpm test
  - D1 migration verification
  - 64 worker/unit tests
  - 3 component tests
- pnpm test:browser
  - 28 browser tests
- pnpm exec wrangler deploy --dry-run
- git diff --check

The retention regression covers expired records, fresh active ownership, an old-but-latest undoable TV advancement, Parent history limits, active Preparation Run preservation, Household cursor bounds, and idempotent repeat cleanup. Existing Household deletion coverage remains green.

Closes #81