### PR TITLE
Reduce recurring D1 Household scans

### DIFF
--- a/docs/d1-index-audit.md
+++ b/docs/d1-index-audit.md
@@ -1,0 +1,55 @@
+# D1 index audit
+
+This audit covers production database `kids-channels` after migrations `0020` and `0021` on 9 August 2026. It uses `wrangler d1 insights`, `EXPLAIN QUERY PLAN`, and the per-query `meta.rows_read` returned by D1.
+
+## What caused the usage spike
+
+The largest operations in the 24-hour production sample were the one-time canonical show migration, not normal Household traffic:
+
+| Statement | Executions | Rows read | Rows written | Classification |
+| --- | ---: | ---: | ---: | --- |
+| Backfill `canonical_shows` | 6 | 12,727,476 | 6,108 | Migration `0020` |
+| Backfill `canonical_show_episodes` | 2 | 1,317,324 | 391,488 | Migration `0020` |
+| Insert episode metadata | 2,580 | 0 | 7,740 | Approval traffic spanning the schema rollout |
+
+The database contained 641 Households, 2,780 Approved Library entries, 509 canonical shows, 65,248 canonical episodes, and 4,383 Channel Schedule rows. Counting all of those tables is itself a full scan: the diagnostic count read 73,561 rows. A Household count is therefore a poor estimate of application database work.
+
+The old pre-normalization episode-list query also remained in the 24-hour lookback window: 200 executions read 452,586 rows. It is historical traffic from before the merged query shape and should age out of insights rather than receive an index for a schema it no longer targets.
+
+## Recurring access paths
+
+Authentication is already efficient. The production query `SELECT ... FROM households WHERE secret = ?` ran 5,977 times and read 5,973 rows in total. `UNIQUE(secret)` maintains `sqlite_autoindex_households_2`, so the explicit `households_secret_idx` duplicates the same key. Migration `0022` drops only the redundant index; its integration test verifies the automatic index remains selected and duplicate secrets remain rejected.
+
+Automatic Preparation Run reconciliation was the material recurring scan:
+
+| Measurement | Before `0022` | After `0022` fixture |
+| --- | ---: | ---: |
+| Households | 641 | 641 |
+| TorBox-configured Households | 1 | 1 |
+| Production rows read per reconciliation | 642 | Capture after rollout |
+| Household access set | All 641 table rows | The 1 partial-index entry |
+| Query plan | `SCAN household`; temporary B-tree for ordering | `SCAN household USING INDEX households_automatic_preparation_idx` |
+
+The production 24-hour sample contained 26 reconciliations with 16,696 total rows read, averaging 642. The before plan was captured directly against production. D1's local Wrangler runtime does not expose `meta.rows_read`, so the integration fixture does not claim a local D1 row count. It uses the same 641-to-1 Household distribution and exact application SQL, and fails unless results stay identical, the partial index is selected, and the temporary sort disappears. After production rollout, repeat the commands below to record the live after measurement.
+
+The new `(created_at, id)` index contains only rows where `torbox_token_ciphertext IS NOT NULL`. New unconfigured Households therefore add no index write. Connecting or disconnecting TorBox changes one index entry; ordinary Channel, Approved Library, stream-selection, and playback writes do not touch it. This narrowly scoped write cost is justified by eliminating the full Household scan every fifteen minutes.
+
+No other index is added. Current high-frequency lookups already use primary, unique, or explicit Household-first indexes. Adding speculative indexes would increase D1 row writes and storage without measured production benefit.
+
+## Rollout and verification
+
+Apply the migration with:
+
+```sh
+pnpm db:migrate:remote
+```
+
+Migration `0022` runs `PRAGMA optimize` after changing the schema so D1 refreshes planner statistics when needed. Then inspect the last day of statements:
+
+```sh
+pnpm exec wrangler d1 insights kids-channels --time-period 1d --sort-by reads --sort-direction DESC --limit 50
+```
+
+Use the automatic reconciliation SQL from `ensureAutomaticTvPreparationForAll` with `EXPLAIN QUERY PLAN`; it must report `households_automatic_preparation_idx` and no temporary B-tree. Its D1 result metadata should approach the number of configured Households rather than all Households.
+
+If production behaviour regresses, apply `migrations/rollback/0022_restore_household_indexes.sql` with `wrangler d1 execute --remote --file`. This removes the partial index, recreates `households_secret_idx`, and refreshes planner statistics. Secret lookup correctness does not depend on rollback because the `UNIQUE(secret)` index remains throughout.

--- a/migrations/0022_audit_household_indexes.sql
+++ b/migrations/0022_audit_household_indexes.sql
@@ -1,0 +1,10 @@
+-- UNIQUE(secret) already maintains sqlite_autoindex_households_2 for authentication lookups.
+DROP INDEX households_secret_idx;
+
+-- Automatic Preparation Run reconciliation only considers Households with TorBox configured.
+-- Keep unconfigured Households out of this index and cover both its ordering and result.
+CREATE INDEX households_automatic_preparation_idx
+  ON households (created_at, id)
+  WHERE torbox_token_ciphertext IS NOT NULL;
+
+PRAGMA optimize;

--- a/migrations/rollback/0022_restore_household_indexes.sql
+++ b/migrations/rollback/0022_restore_household_indexes.sql
@@ -1,0 +1,6 @@
+DROP INDEX households_automatic_preparation_idx;
+
+CREATE INDEX households_secret_idx
+  ON households (secret);
+
+PRAGMA optimize;

--- a/scripts/test-normalize-show-metadata-migration.mjs
+++ b/scripts/test-normalize-show-metadata-migration.mjs
@@ -21,6 +21,24 @@ function query(sql) {
   return result[0]?.results ?? [];
 }
 
+const automaticPreparationSql = `SELECT household.id FROM households household
+  WHERE household.torbox_token_ciphertext IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM tv_preparation_runs run
+      WHERE run.household_id = household.id AND run.status IN ('queued', 'running')
+    )
+    AND EXISTS (
+      SELECT 1 FROM channel_schedule schedule
+      WHERE schedule.household_id = household.id AND schedule.channel = 'tv'
+        AND NOT EXISTS (
+          SELECT 1 FROM stream_selections selection
+          WHERE selection.household_id = household.id AND selection.content_type = 'series'
+            AND selection.video_id = schedule.video_id AND selection.download_pending = 0
+            AND selection.stale_at > '2026-08-09T00:00:00.000Z'
+        )
+    )
+  ORDER BY household.created_at LIMIT 100`;
+
 try {
   const legacyMigrations = readdirSync(join(root, "migrations"))
     .filter((name) => /^00(0[1-9]|1\d)_.*\.sql$/.test(name))
@@ -70,7 +88,59 @@ try {
     throw new Error("Channel retention cursor migration was not applied");
   }
 
-  console.log("D1 migrations preserved Household state, deduplicated canonical rows, and installed retention state.");
+  execute(["--command", `WITH RECURSIVE sequence(value) AS (
+      VALUES(1) UNION ALL SELECT value + 1 FROM sequence WHERE value < 639
+    )
+    INSERT INTO households (id, secret, pin_salt, pin_hash, created_at)
+    SELECT printf('benchmark-%04d', value), printf('benchmark-secret-%04d', value),
+      'salt', 'hash', printf('2026-08-09T00:%02d:00.000Z', value % 60)
+    FROM sequence`]);
+  execute(["--command", "UPDATE households SET torbox_token_ciphertext = 'configured' WHERE id = 'household-a'"]);
+
+  const benchmarkCounts = query(`SELECT COUNT(*) AS households,
+    COUNT(torbox_token_ciphertext) AS configured_households FROM households`)[0];
+  const beforeIndex = query(automaticPreparationSql);
+  const beforePlan = query(`EXPLAIN QUERY PLAN ${automaticPreparationSql}`);
+  if (benchmarkCounts?.households !== 641 || benchmarkCounts.configured_households !== 1
+    || JSON.stringify(beforeIndex) !== JSON.stringify([{ id: "household-a" }])
+    || !beforePlan.some((row) => row.detail === "SCAN household")
+    || !beforePlan.some((row) => row.detail === "USE TEMP B-TREE FOR ORDER BY")) {
+    throw new Error(`automatic preparation baseline changed: ${JSON.stringify({ benchmarkCounts, beforeIndex, beforePlan })}`);
+  }
+
+  execute(["--file", join(root, "migrations/0022_audit_household_indexes.sql")]);
+
+  const afterIndex = query(automaticPreparationSql);
+  const afterPlan = query(`EXPLAIN QUERY PLAN ${automaticPreparationSql}`);
+  if (JSON.stringify(afterIndex) !== JSON.stringify(beforeIndex)
+    || !afterPlan.some((row) => row.detail.includes("USING INDEX households_automatic_preparation_idx"))
+    || afterPlan.some((row) => row.detail === "USE TEMP B-TREE FOR ORDER BY")) {
+    throw new Error(`automatic preparation index was ineffective: ${JSON.stringify({ beforeIndex, afterIndex, afterPlan })}`);
+  }
+
+  const secretPlan = query("EXPLAIN QUERY PLAN SELECT id FROM households WHERE secret = 'secret-a'");
+  if (!secretPlan.some((row) => row.detail.includes("sqlite_autoindex_households_2 (secret=?)"))) {
+    throw new Error(`Household secret lookup lost its UNIQUE access path: ${JSON.stringify(secretPlan)}`);
+  }
+  let duplicateSecretRejected = false;
+  try {
+    execute(["--command", `INSERT INTO households (id, secret, pin_salt, pin_hash, created_at)
+      VALUES ('duplicate-secret', 'secret-a', 'salt', 'hash', '2026-08-09T01:00:00.000Z')`]);
+  } catch {
+    duplicateSecretRejected = true;
+  }
+  if (!duplicateSecretRejected) throw new Error("Household secret uniqueness was not enforced");
+
+  execute(["--file", join(root, "migrations/rollback/0022_restore_household_indexes.sql")]);
+  const rolledBackIndexes = query(`SELECT name FROM sqlite_schema
+    WHERE type = 'index' AND name IN ('households_secret_idx', 'households_automatic_preparation_idx')
+    ORDER BY name`);
+  if (JSON.stringify(rolledBackIndexes) !== JSON.stringify([{ name: "households_secret_idx" }])) {
+    throw new Error(`Household index rollback failed: ${JSON.stringify(rolledBackIndexes)}`);
+  }
+  execute(["--file", join(root, "migrations/0022_audit_household_indexes.sql")]);
+
+  console.log("D1 migrations preserved Household state and replaced the 641-row automatic preparation scan with partial-index access.");
 } finally {
   rmSync(persistence, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
- remove the explicit Household secret index duplicated by `UNIQUE(secret)`
- add a partial covering index for automatic Preparation Run reconciliation
- refresh planner statistics and provide an explicit rollback
- document production D1 insights, query plans, and rollout verification
- extend migration integration coverage for access paths, uniqueness, and rollback

## Production evidence
- migrations through `0021` are applied; `0022` is intentionally still pending
- 641 Households exist, but only 1 has TorBox configured
- automatic reconciliation ran 26 times and read 16,696 rows in 24 hours (642 average)
- its production plan scans all Households and creates a temporary ordering B-tree
- authentication ran 5,977 times for 5,973 total rows read, confirming the UNIQUE access path is already effective
- the largest read/write spikes were one-time canonical metadata backfills from migration `0020`

The 641-to-1 integration fixture verifies that the partial index preserves results, replaces the full Household scan, and removes the temporary sort. Local Wrangler does not report D1 `meta.rows_read`, so the audit explicitly reserves the numerical after measurement for post-rollout production verification.

## Verification
- `pnpm test`
- `pnpm test:browser`
- `pnpm typecheck`
- `git diff --check`

Closes #82
