### PR TITLE
Stop Approved Library from materializing every episode

### DIFF
--- a/src/approved-library.ts
+++ b/src/approved-library.ts
@@ -167,10 +167,7 @@ type SummaryRow = StoredProgramme & {
   progress_released_at: string | null;
 };
 
-/** A compact Parent Page projection. Episode catalogues are deliberately loaded only by
- * the programme-detail endpoint; this list includes at most the single Show Progress episode. */
-export async function approvedLibrary(db: D1Database, householdId: string): Promise<ApprovedProgrammeSummary[]> {
-  const rows = await db.prepare(`SELECT p.id, p.imdb_id, p.content_type,
+export const APPROVED_LIBRARY_SQL = `SELECT p.id, p.imdb_id, p.content_type,
       CASE WHEN p.content_type = 'show' THEN canonical.title ELSE p.title END AS title,
       CASE WHEN p.content_type = 'show' THEN canonical.description ELSE p.description END AS description,
       CASE WHEN p.content_type = 'show' THEN canonical.poster ELSE p.poster END AS poster,
@@ -189,10 +186,16 @@ export async function approvedLibrary(db: D1Database, householdId: string): Prom
     LEFT JOIN current_programmes current
       ON current.household_id = p.household_id AND current.programme_id = p.id
     LEFT JOIN show_progress progress ON progress.programme_id = p.id
-    LEFT JOIN show_episodes episode
-      ON episode.programme_id = p.id AND episode.video_id = progress.next_video_id
+    LEFT JOIN canonical_show_episodes episode
+      ON p.content_type = 'show' AND episode.show_imdb_id = p.imdb_id
+        AND episode.video_id = progress.next_video_id
     WHERE p.household_id = ?
-    ORDER BY p.approved_at, title`).bind(householdId).all<SummaryRow>();
+    ORDER BY p.approved_at, title`;
+
+/** A compact Parent Page projection. Episode catalogues are deliberately loaded only by
+ * the programme-detail endpoint; this list includes at most the single Show Progress episode. */
+export async function approvedLibrary(db: D1Database, householdId: string): Promise<ApprovedProgrammeSummary[]> {
+  const rows = await db.prepare(APPROVED_LIBRARY_SQL).bind(householdId).all<SummaryRow>();
 
   return rows.results.map((row) => {
     const programme = programmeFromRow(row);

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -12,6 +12,7 @@ import {
   tvPreparationRun,
 } from "../src/tv-preparation";
 import { refreshTvChannelSchedule, requestTvProgramme, tvChannelSchedule } from "../src/tv-channel";
+import { APPROVED_LIBRARY_SQL } from "../src/approved-library";
 
 const SELF = {
   fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
@@ -679,6 +680,16 @@ describe("Cinemeta Approved Library", () => {
     });
     return sessionHeaders(response);
   }
+
+  it("looks up Show Progress without materializing every Household's episodes", async () => {
+    const plan = await env.DB.prepare(`EXPLAIN QUERY PLAN ${APPROVED_LIBRARY_SQL}`)
+      .bind("query-plan-household").all<{ detail: string }>();
+
+    expect(plan.results.map((row) => row.detail)).not.toContain("MATERIALIZE show_episodes");
+    expect(plan.results.some((row) => row.detail.includes(
+      "sqlite_autoindex_canonical_show_episodes_1 (show_imdb_id=? AND video_id=?)",
+    ))).toBe(true);
+  });
 
   it("searches shows and movies with distinguishing metadata and artwork", async () => {
     const created = await create();


### PR DESCRIPTION
## Summary
- join Show Progress directly to `canonical_show_episodes` by `(show_imdb_id, video_id)`
- avoid materializing the cross-Household `show_episodes` compatibility view
- export the exact call-site SQL so the integration test can guard its production query plan

## Production evidence
Over the clean 12-hour window, the deployed Approved Library query consumed 2,777,173 of 2,985,261 rows read (93%). It averaged 308,574 rows per execution. Production `EXPLAIN QUERY PLAN` confirmed `MATERIALIZE show_episodes`, followed by a scan across Approved Library programmes and canonical episodes.

Running the replacement SQL read-only against production's largest Approved Library returned 784 programmes with 3,137 rows read. That is more than 99% below the deployed query's average while exercising a larger-than-typical result set.

The regression test failed against the old query with `MATERIALIZE show_episodes`, then passed after the direct composite-primary-key lookup was introduced.

## Verification
- targeted red/green query-plan test
- `pnpm test` — 65 backend tests and 3 component tests
- `pnpm test:browser` — 28 tests
- `pnpm typecheck`
- `git diff --check`
